### PR TITLE
Yaml validation with yamale lib

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,11 @@ name = "pypi"
 
 
 [packages]
+
 pyyaml = "*"
 python-dateutil = "*"
+yamale = "*"
+
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aea897f2a6b726b4a50884738e05211e969c252398840ca50fec2c72d0a0ca6c"
+            "sha256": "e8851035a4ffb0d2799b1b8629b7adf63adb10660f12208525bfc048cce00601"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "17.4.0",
+            "platform_release": "17.2.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.2.0: Fri Sep 29 18:27:05 PDT 2017; root:xnu-4570.20.62~3/RELEASE_X86_64",
             "python_full_version": "3.6.3",
             "python_version": "3.6",
             "sys_platform": "darwin"
@@ -31,10 +31,10 @@
     "default": {
         "python-dateutil": {
             "hashes": [
-                "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c",
-                "sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca"
+                "sha256:07009062406cffd554a9b4135cd2ff167c9bf6b7aac61fe946c93e69fad1bbd8",
+                "sha256:8f95bb7e6edbb2456a51a1fb58c8dca942024b4f5844cae62c90aa88afe6e300"
             ],
-            "version": "==2.6.1"
+            "version": "==2.7.0"
         },
         "pyyaml": {
             "hashes": [
@@ -61,6 +61,12 @@
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
             ],
             "version": "==1.11.0"
+        },
+        "yamale": {
+            "hashes": [
+                "sha256:18f921a8272b85b1d74df19e18f8656254c4561ef8abee323bbdbf411f79ec0b"
+            ],
+            "version": "==1.7.0"
         }
     },
     "develop": {

--- a/blurr/core/base.py
+++ b/blurr/core/base.py
@@ -17,19 +17,11 @@ class DTCType(Validator):
     # all valid types would go here, I just made this up
     VALUES = list(SCHEMA_MAP.keys()) + ['ProductML:DTC:Streaming']
 
-    __name__ = "DTC Type"
-
     def _is_valid(self, value):
         return value in self.VALUES
 
-    def __str__(self):
-        return "DTC Valid Type"
-
-    def __repr__(self):
-        return self.__str__()
-
     def get_name(self):
-        return self.__str__()
+        return "DTC Valid Type"
 
 
 class BaseSchema(ABC):

--- a/blurr/core/base.py
+++ b/blurr/core/base.py
@@ -1,27 +1,10 @@
 from typing import Dict, Any, Type
 
-import yaml
 from abc import ABC, abstractmethod
-from yamale.schema import Schema, Data
-from yamale.validators import Validator, DefaultValidators
 
-from blurr.core.errors import InvalidSchemaError, SnapshotError
+from blurr.core.errors import SnapshotError
 from blurr.core.evaluation import Expression, EvaluationContext
-from blurr.core.loader import TypeLoader, SCHEMA_MAP
-
-
-# This would be in a more central place along with other validation code
-class DTCType(Validator):
-    TAG = 'dtc_type'
-
-    # all valid types would go here, I just made this up
-    VALUES = list(SCHEMA_MAP.keys()) + ['ProductML:DTC:Streaming']
-
-    def _is_valid(self, value):
-        return value in self.VALUES
-
-    def get_name(self):
-        return "DTC Valid Type"
+from blurr.core.loader import TypeLoader
 
 
 class BaseSchema(ABC):
@@ -35,26 +18,11 @@ class BaseSchema(ABC):
     ATTRIBUTE_TYPE = 'Type'
     ATTRIBUTE_WHEN = 'When'
 
-    SCHEMA = '''
-        Name: str(min=1)
-        Type: dtc_type()
-        When: str(min=1, required=False)
-    '''
-
     def __init__(self, spec: Dict[str, Any]) -> None:
         """
         A schema object must be initialized with a schema spec
         :param spec: Dictionary representation of the YAML schema spec
-        """
-        validators = DefaultValidators.copy()
-        validators['dtc_type'] = DTCType
-
-        self.schema = Schema(
-            yaml.load(self.SCHEMA),
-            name=self.__class__.__name__,
-            validators=validators)
-
-        self.__validate_spec(spec)
+       sh """
         self.__load_spec(spec)
 
     @abstractmethod
@@ -84,15 +52,6 @@ class BaseSchema(ABC):
 
         # Invokes the loads of the subclass
         self.load(spec)
-
-    def __validate_spec(self, spec: Dict[str, Any]) -> None:
-        """
-        Validates the schema spec.  Raises exceptions if errors are found.
-        """
-        try:
-            self.schema.validate(Data(spec, name="spec"))
-        except ValueError as e:
-            raise InvalidSchemaError(str(e))
 
 
 class BaseSchemaCollection(BaseSchema, ABC):

--- a/blurr/core/base.py
+++ b/blurr/core/base.py
@@ -1,9 +1,35 @@
-from abc import ABC, abstractmethod
 from typing import Dict, Any, Type
+
+import yaml
+from abc import ABC, abstractmethod
+from yamale.schema import Schema, Data
+from yamale.validators import Validator, DefaultValidators
 
 from blurr.core.errors import InvalidSchemaError, SnapshotError
 from blurr.core.evaluation import Expression, EvaluationContext
-from blurr.core.loader import TypeLoader
+from blurr.core.loader import TypeLoader, SCHEMA_MAP
+
+
+# This would be in a more central place along with other validation code
+class DTCType(Validator):
+    TAG = 'dtc_type'
+
+    # all valid types would go here, I just made this up
+    VALUES = list(SCHEMA_MAP.keys()) + ['ProductML:DTC:Streaming']
+
+    __name__ = "DTC Type"
+
+    def _is_valid(self, value):
+        return value in self.VALUES
+
+    def __str__(self):
+        return "DTC Valid Type"
+
+    def __repr__(self):
+        return self.__str__()
+
+    def get_name(self):
+        return self.__str__()
 
 
 class BaseSchema(ABC):
@@ -17,12 +43,24 @@ class BaseSchema(ABC):
     ATTRIBUTE_TYPE = 'Type'
     ATTRIBUTE_WHEN = 'When'
 
+    SCHEMA = '''
+        Name: str(min=1)
+        Type: dtc_type()
+        When: str(min=1, required=False)
+    '''
+
     def __init__(self, spec: Dict[str, Any]) -> None:
         """
         A schema object must be initialized with a schema spec
         :param spec: Dictionary representation of the YAML schema spec
         """
-        # Load the schema spec into the current object
+        validators = DefaultValidators.copy()
+        validators['dtc_type'] = DTCType
+
+        self.schema = Schema(
+            yaml.load(self.SCHEMA),
+            name=self.__class__.__name__,
+            validators=validators)
 
         self.__validate_spec(spec)
         self.__load_spec(spec)
@@ -59,45 +97,10 @@ class BaseSchema(ABC):
         """
         Validates the schema spec.  Raises exceptions if errors are found.
         """
-        self.validate_required_attribute(spec, self.ATTRIBUTE_NAME)
-        self.validate_required_attribute(spec, self.ATTRIBUTE_TYPE)
-
-        # Invokes the validations of the subclasses
-        self.validate(spec)
-
-    def validate_required_attribute(self, spec: Dict[str, Any],
-                                    attribute: str):
-        """
-        Raises an error if a required attribute is not defined
-        or contains an empty value
-        :param spec: Schema specifications
-        :param attribute: Attribute that is being validated
-        """
-        if attribute not in spec:
-            self.raise_validation_error(spec, attribute,
-                                        'Required attribute missing.')
-
-        if isinstance(spec[attribute], str) and spec[attribute].isspace():
-            self.raise_validation_error(spec, attribute,
-                                        'Invalid attribute value.')
-
-    def raise_validation_error(self, spec: Dict[str, Any], attribute: str,
-                               message: str):
-        """
-        Raises an InvalidSchemaException exception with an expressive message
-        :param spec: Schema specification dictionary
-        :param attribute: Attribute with error
-        :param message: Description of error encountered
-        """
-        error_message = ('\nError processing schema spec:'
-                         '\n\tSpec: {name}'
-                         '\n\tAttribute: {attribute}'
-                         '\n\tError Message: {message}') \
-            .format(
-            name=spec.get(self.ATTRIBUTE_NAME, str(spec)),
-            attribute=attribute,
-            message=message)
-        raise InvalidSchemaError(error_message)
+        try:
+            self.schema.validate(Data(spec, name="spec"))
+        except ValueError as e:
+            raise InvalidSchemaError(str(e))
 
 
 class BaseSchemaCollection(BaseSchema, ABC):

--- a/blurr/core/syntax/dtc_streaming_schema.yml
+++ b/blurr/core/syntax/dtc_streaming_schema.yml
@@ -1,0 +1,47 @@
+Type: enum('ProductML:DTC:Streaming')
+Version: enum('2018-03-01')
+Description: str(min=1, required=False)
+Name: identifier()
+Identity: expression()
+Time: expression(required=False)
+When: expression(required=False)
+Store: include('dynamodb_store')
+DataGroups: list(any(include('data_group_variable'), include('data_group_identity'), include('data_group_session')), min=1)
+
+---
+
+data_group_variable:
+  Name: identifier()
+  Type: enum('ProductML:DTC:DataGroup:Variable')
+  Store: identifier(required=False)
+  When: expression(required=False)
+  Fields: list(include('field'), min=1)
+
+data_group_identity:
+  Name: identifier()
+  Type: enum('ProductML:DTC:DataGroup:IdentityAggregate')
+  Store: identifier(required=False)
+  When: expression(required=False)
+  Fields: list(include('field'), min=1)
+
+data_group_session:
+  Name: identifier()
+  Type: enum('ProductML:DTC:DataGroup:SessionAggregate')
+  Store: identifier(required=False)
+  When: expression(required=False)
+  Split: expression(required=False)
+  Fields: list(include('field'), min=1)
+
+field:
+  Name: identifier()
+  Type: data_type(required=False)
+  Value: expression()
+  When: expression(required=False)
+  Atomic: bool(required=False)
+
+dynamodb_store:
+  Type: enum('ProductML:DTC:Storage:DynamoDB')
+  Name: identifier()
+  RetentionDays: int(min=1, required=False)
+  ReadWriteUnits: int(min=1, required=False)
+  Table: identifier()

--- a/blurr/core/syntax/dtc_window_schema.yml
+++ b/blurr/core/syntax/dtc_window_schema.yml
@@ -1,0 +1,48 @@
+Type: enum('ProductML:DTC:Window')
+Version: enum('2018-03-01')
+Description: str(min=1, required=False)
+Name: identifier()
+SourceDTC: identifier()
+Time: expression(required=False)
+When: expression(required=False)
+Anchor: include('anchor')
+Store: include('s3_store')
+DataGroups: list(any(include('data_group_variable'), include('data_group_anchor')), min=1)
+
+---
+
+anchor:
+  Condition: expression()
+  Max: int(min=1, required=False)
+
+data_group_variable:
+  Name: identifier()
+  Type: enum('ProductML:DTC:DataGroup:Variable')
+  Store: identifier(required=False)
+  When: expression(required=False)
+  Fields: list(include('field'), min=1)
+
+data_group_anchor:
+  Name: identifier()
+  Type: enum('ProductML:DTC:DataGroup:AnchorAggregate')
+  When: expression(required=False)
+  Window: include('window', required=False)
+  Fields: list(include('field'), min=1)
+
+window:
+  Type: enum('Day', 'Hour', 'Count')
+  Value: int()
+  Source: identifier()
+
+field:
+  Name: identifier()
+  Type: data_type(required=False)
+  Value: expression()
+  When: expression(required=False)
+  Atomic: bool(required=False)
+
+s3_store:
+  Type: enum('ProductML:DTC:Storage:S3')
+  Name: identifier()
+  Bucket: identifier()
+  Prefix: identifier()

--- a/blurr/core/syntax/schema_validator.py
+++ b/blurr/core/syntax/schema_validator.py
@@ -1,0 +1,91 @@
+import ast
+
+import re
+from yamale import yamale
+from yamale.schema import Data
+from yamale.validators import DefaultValidators, Validator
+
+from blurr.core.errors import InvalidSchemaError
+
+
+def is_expression(s) -> bool:
+    try:
+        ast.parse(s)
+    except SyntaxError:
+        return False
+    return True
+
+
+def is_identifier(s) -> bool:
+    return len(re.findall(r"[^\S]", s)) == 0
+
+
+class DataType(Validator):
+    TAG = 'data_type'
+
+    VALUES = [
+        'integer', 'boolean', 'string', 'datetime', 'float', 'map', 'list',
+        'set'
+    ]
+
+    def _is_valid(self, value):
+        return value in self.VALUES
+
+    def get_name(self):
+        return "DTC Valid Data Type"
+
+
+class Identifier(Validator):
+    TAG = 'identifier'
+
+    def _is_valid(self, value):
+        return is_identifier(value)
+
+    def get_name(self):
+        return "Identifier"
+
+
+class Expression(Validator):
+    TAG = 'expression'
+
+    def _is_valid(self, value):
+        return is_expression(value)
+
+    def get_name(self):
+        return "Expression"
+
+
+VALIDATORS = {
+    **DefaultValidators.copy(), "data_type": DataType,
+    "identifier": Identifier,
+    "expression": Expression
+}
+
+STREAMING_SCHEMA = yamale.make_schema(
+    'blurr/core/syntax/dtc_streaming_schema.yml', validators=VALIDATORS)
+
+WINDOW_SCHEMA = yamale.make_schema(
+    'blurr/core/syntax/dtc_window_schema.yml', validators=VALIDATORS)
+
+
+def _validate_window(dtc_dict, name):
+    try:
+        WINDOW_SCHEMA.validate(Data(dtc_dict, name))
+    except ValueError as e:
+        raise InvalidSchemaError(str(e))
+
+
+def _validate_streaming(dtc_dict, name):
+    try:
+        STREAMING_SCHEMA.validate(Data(dtc_dict, name))
+    except ValueError as e:
+        raise InvalidSchemaError(str(e))
+
+
+def validate(dtc_dict, name="dtc"):
+    if dtc_dict["Type"] == "ProductML:DTC:Window":
+        _validate_window(dtc_dict, name)
+    elif dtc_dict["Type"] == "ProductML:DTC:Streaming":
+        _validate_streaming(dtc_dict, name)
+    else:
+        raise ValueError("Document is not a valid DTC")

--- a/blurr/runner/local_runner.py
+++ b/blurr/runner/local_runner.py
@@ -1,10 +1,13 @@
-import yaml
 import json
-from blurr.core.streaming_transformer import StreamingTransformerSchema, StreamingTransformer
-from blurr.core.record import Record
-from blurr.core.evaluation import Context, EvaluationContext
-from blurr.store.local_store import LocalStore
+
+import yaml
 from dateutil import parser
+
+from blurr.core.evaluation import Context
+from blurr.core.record import Record
+from blurr.core.streaming_transformer import StreamingTransformerSchema, StreamingTransformer
+from blurr.core.syntax.schema_validator import validate
+from blurr.store.local_store import LocalStore
 
 
 class LocalRunner:
@@ -16,6 +19,11 @@ class LocalRunner:
         self._user_transformer = {}
         self._exec_context = Context()
         self._exec_context.add('parser', parser)
+
+        self._validate_dtc_syntax()
+
+    def _validate_dtc_syntax(self):
+        validate(self._stream_dtc)
 
     def _consume_record(self, record):
         source_context = Context({'source': record})

--- a/tests/core/base_schema_test.py
+++ b/tests/core/base_schema_test.py
@@ -1,9 +1,10 @@
 from typing import Dict, Any
-from pytest import fixture, raises, mark
+
+import yaml
+from pytest import fixture, mark
+
 from blurr.core.base import BaseSchema
 from blurr.core.evaluation import Expression, EvaluationContext
-from blurr.core.errors import InvalidSchemaError
-import yaml
 
 TEST_SCHEMA_SPEC = '''
 Name: TestField
@@ -33,7 +34,8 @@ class TestSchema(BaseSchema):
         pass
 
 
-def test_base_schema_valid(test_schema_spec: Dict[str, Any]) -> None:
+def test_base_schema_with_all_attributes(
+        test_schema_spec: Dict[str, Any]) -> None:
     test_schema = TestSchema(test_schema_spec)
     assert test_schema.name == test_schema_spec[BaseSchema.ATTRIBUTE_NAME]
     assert test_schema.type == test_schema_spec[BaseSchema.ATTRIBUTE_TYPE]
@@ -41,34 +43,7 @@ def test_base_schema_valid(test_schema_spec: Dict[str, Any]) -> None:
     assert test_schema.when.evaluate(EvaluationContext())
 
 
-def test_base_schema_empty() -> None:
-    with raises(InvalidSchemaError) as err:
-        TestSchema({})
-    assert "Error validating data spec with schema TestSchema" in str(
-        err.value)
-    assert "Name: Required field missing" in str(err.value)
-    assert "Type: Required field missing" in str(err.value)
-
-
-def test_base_schema_name_missing(test_schema_spec: Dict[str, Any]) -> None:
-    del test_schema_spec[BaseSchema.ATTRIBUTE_NAME]
-    with raises(InvalidSchemaError) as err:
-        TestSchema(test_schema_spec)
-    assert "Error validating data spec with schema TestSchema" in str(
-        err.value)
-    assert "Name: Required field missing" in str(err.value)
-
-
-def test_base_schema_type_missing(test_schema_spec: Dict[str, Any]) -> None:
-    del test_schema_spec[BaseSchema.ATTRIBUTE_TYPE]
-    with raises(InvalidSchemaError) as err:
-        TestSchema(test_schema_spec)
-    assert "Error validating data spec with schema TestSchema" in str(
-        err.value)
-    assert "Type: Required field missing" in str(err.value)
-
-
-def test_base_schema_with_attribute_when_missing_is_valid(
+def test_base_schema_with_no_attribute_when(
         test_schema_spec: Dict[str, Any]) -> None:
     del test_schema_spec[BaseSchema.ATTRIBUTE_WHEN]
     TestSchema(test_schema_spec)
@@ -76,12 +51,3 @@ def test_base_schema_with_attribute_when_missing_is_valid(
     assert test_schema.name == test_schema_spec[BaseSchema.ATTRIBUTE_NAME]
     assert test_schema.type == test_schema_spec[BaseSchema.ATTRIBUTE_TYPE]
     assert test_schema.when is None
-
-
-def test_invalid_type_raises_error(test_schema_spec: Dict[str, Any]) -> None:
-    test_schema_spec[BaseSchema.ATTRIBUTE_TYPE] = "foo"
-    with raises(InvalidSchemaError) as err:
-        TestSchema(test_schema_spec)
-    assert "Error validating data spec with schema TestSchema" in str(
-        err.value)
-    assert "Type: 'foo' is not a DTC Valid Type" in str(err.value)

--- a/tests/core/base_schema_test.py
+++ b/tests/core/base_schema_test.py
@@ -42,17 +42,46 @@ def test_base_schema_valid(test_schema_spec: Dict[str, Any]) -> None:
 
 
 def test_base_schema_empty() -> None:
-    with raises(InvalidSchemaError, Message='Required attribute missing.'):
+    with raises(InvalidSchemaError) as err:
         TestSchema({})
+    assert "Error validating data spec with schema TestSchema" in str(
+        err.value)
+    assert "Name: Required field missing" in str(err.value)
+    assert "Type: Required field missing" in str(err.value)
 
 
 def test_base_schema_name_missing(test_schema_spec: Dict[str, Any]) -> None:
     del test_schema_spec[BaseSchema.ATTRIBUTE_NAME]
-    with raises(InvalidSchemaError, Message='Required attribute missing.'):
+    with raises(InvalidSchemaError) as err:
         TestSchema(test_schema_spec)
+    assert "Error validating data spec with schema TestSchema" in str(
+        err.value)
+    assert "Name: Required field missing" in str(err.value)
 
 
 def test_base_schema_type_missing(test_schema_spec: Dict[str, Any]) -> None:
     del test_schema_spec[BaseSchema.ATTRIBUTE_TYPE]
-    with raises(InvalidSchemaError, Message='Required attribute missing.'):
+    with raises(InvalidSchemaError) as err:
         TestSchema(test_schema_spec)
+    assert "Error validating data spec with schema TestSchema" in str(
+        err.value)
+    assert "Type: Required field missing" in str(err.value)
+
+
+def test_base_schema_with_attribute_when_missing_is_valid(
+        test_schema_spec: Dict[str, Any]) -> None:
+    del test_schema_spec[BaseSchema.ATTRIBUTE_WHEN]
+    TestSchema(test_schema_spec)
+    test_schema = TestSchema(test_schema_spec)
+    assert test_schema.name == test_schema_spec[BaseSchema.ATTRIBUTE_NAME]
+    assert test_schema.type == test_schema_spec[BaseSchema.ATTRIBUTE_TYPE]
+    assert test_schema.when is None
+
+
+def test_invalid_type_raises_error(test_schema_spec: Dict[str, Any]) -> None:
+    test_schema_spec[BaseSchema.ATTRIBUTE_TYPE] = "foo"
+    with raises(InvalidSchemaError) as err:
+        TestSchema(test_schema_spec)
+    assert "Error validating data spec with schema TestSchema" in str(
+        err.value)
+    assert "Type: 'foo' is not a DTC Valid Type" in str(err.value)

--- a/tests/core/syntax/dtcs/invalid_datagroup_has_no_fields.yml
+++ b/tests/core/syntax/dtcs/invalid_datagroup_has_no_fields.yml
@@ -1,0 +1,18 @@
+Type: ProductML:DTC:Streaming
+Version: '2018-03-01'
+Description: Example
+Name: example_name
+Identity: source.user_id
+When: source.package_version = '1.0'
+Store:
+   Type: ProductML:DTC:Storage:DynamoDB
+   Name: offer_ai_dynamo
+   RetentionDays: 180
+   ReadWriteUnits: 5
+   Table: ProductML_Test_Win_Ratios
+DataGroups:
+ - Type: ProductML:DTC:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+
+   # DATAGROUP SHOULD HAVE FIELDS

--- a/tests/core/syntax/dtcs/invalid_incorrect_expression.yml
+++ b/tests/core/syntax/dtcs/invalid_incorrect_expression.yml
@@ -1,0 +1,24 @@
+Type: ProductML:DTC:Streaming
+Version: '2018-03-01'
+Description: Example
+Name: example_name
+Identity: source.user_id
+
+
+# SHOULD BE A CORRECT PYTHON EXPRESSION
+When: x == senor roy
+
+
+Store:
+   Type: ProductML:DTC:Storage:DynamoDB
+   Name: offer_ai_dynamo
+   RetentionDays: 180
+   ReadWriteUnits: 5
+   Table: ProductML_Test_Win_Ratios
+DataGroups:
+ - Type: ProductML:DTC:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+   Fields:
+     - Name: user_id
+       Value: source.customer_identifier

--- a/tests/core/syntax/dtcs/invalid_non_existing_data_type.yml
+++ b/tests/core/syntax/dtcs/invalid_non_existing_data_type.yml
@@ -1,0 +1,26 @@
+Type: ProductML:DTC:Streaming
+Version: '2018-03-01'
+Description: Example
+Name: example_name
+Identity: source.user_id
+When: source.package_version = '1.0'
+Store:
+   Type: ProductML:DTC:Storage:DynamoDB
+   Name: offer_ai_dynamo
+   RetentionDays: 180
+   ReadWriteUnits: 5
+   Table: ProductML_Test_Win_Ratios
+DataGroups:
+ - Type: ProductML:DTC:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+   Fields:
+     - Name: user_id
+
+
+       # SHOULD BE ONE OF DEFINED DATA TYPES
+       Type: foo
+
+
+
+       Value: source.customer_identifier

--- a/tests/core/syntax/dtcs/invalid_string_instead_integer.yml
+++ b/tests/core/syntax/dtcs/invalid_string_instead_integer.yml
@@ -1,0 +1,24 @@
+Type: ProductML:DTC:Streaming
+Version: '2018-03-01'
+Description: Example
+Name: example_name
+Identity: source.user_id
+When: source.package_version = '1.0'
+Store:
+   Type: ProductML:DTC:Storage:DynamoDB
+   Name: offer_ai_dynamo
+   RetentionDays: 180
+
+
+   # SHOULD BE AN INTEGER
+   ReadWriteUnits: five
+
+
+   Table: ProductML_Test_Win_Ratios
+DataGroups:
+ - Type: ProductML:DTC:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+   Fields:
+     - Name: user_id
+       Value: source.customer_identifier

--- a/tests/core/syntax/dtcs/invalid_wrong_version.yml
+++ b/tests/core/syntax/dtcs/invalid_wrong_version.yml
@@ -1,0 +1,24 @@
+Type: ProductML:DTC:Streaming
+
+
+# WRONG VERSION
+Version: '2088-03-01'
+
+
+Description: Example
+Name: example_name
+Identity: source.user_id
+When: source.package_version = '1.0'
+Store:
+   Type: ProductML:DTC:Storage:DynamoDB
+   Name: offer_ai_dynamo
+   RetentionDays: 180
+   ReadWriteUnits: 5
+   Table: ProductML_Test_Win_Ratios
+DataGroups:
+ - Type: ProductML:DTC:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+   Fields:
+     - Name: user_id
+       Value: source.customer_identifier

--- a/tests/core/syntax/dtcs/valid_basic_streaming.yml
+++ b/tests/core/syntax/dtcs/valid_basic_streaming.yml
@@ -1,0 +1,23 @@
+Type: ProductML:DTC:Streaming
+Version: '2018-03-01'
+Description: Example
+Name: example_name
+Identity: source.user_id
+When: source.package_version = '1.0'
+Store:
+   Type: ProductML:DTC:Storage:DynamoDB
+   Name: offer_ai_dynamo
+   RetentionDays: 180
+   ReadWriteUnits: 5
+   Table: ProductML_Test_Win_Ratios
+DataGroups:
+ - Type: ProductML:DTC:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+   Fields:
+     - Name: user_id
+       Value: source.customer_identifier
+       Atomic: true
+     - Name: country
+       Value: source.country
+       When: last_session = None

--- a/tests/core/syntax/dtcs/valid_basic_window.yml
+++ b/tests/core/syntax/dtcs/valid_basic_window.yml
@@ -1,0 +1,30 @@
+Type: ProductML:DTC:Window
+Version: '2018-03-01'
+Description: Second Level processing for feature generation
+Name: ProductMLExample
+SourceDTC: offer_ai_v1
+Anchor:
+  Condition:  offer_ai_v1.game_stats.offer_type != ''
+  Max: 1
+Store:
+  Type: ProductML:DTC:Storage:S3
+  Name: s3
+  Bucket: productml-test
+  Prefix: /dtc-test/window/
+DataGroups:
+  - Type: ProductML:DTC:DataGroup:AnchorAggregate
+    Name: last_session
+    Window:
+      Type: Count
+      Value: -1
+      Source: offer_ai_v1.game_stats
+      Name: prev_session
+    Fields:
+      - Name: games_played_last_session
+        Type: integer
+        Value: prev_session.games_played[0]
+        When: last_session = None
+      - Name: win_ratio_last_session
+        Type: float
+        Value: prev_session.win_ratio[0]
+        Atomic: true

--- a/tests/core/syntax/schema_validator_test.py
+++ b/tests/core/syntax/schema_validator_test.py
@@ -1,0 +1,81 @@
+import yaml
+from pytest import raises
+
+from blurr.core.errors import InvalidSchemaError
+from blurr.core.syntax.schema_validator import is_identifier, is_expression, validate
+
+
+def test_valid_identifier():
+    assert is_identifier("valid_string_with_numbers_and_!@£$$%%^&*()")
+
+
+def test_invalid_identifiers():
+    assert not is_identifier("identifier with spaces")
+    assert not is_identifier("identifier_with\t_tabs")
+    assert not is_identifier("identifier_with\n_new_lines")
+
+
+def test_valid_expression():
+    assert is_expression("is_valid_python('1 // 2')")
+
+
+def test_invalid_expression():
+    assert not is_expression("regular text")
+    assert not is_expression("is_invalid_python(1 /// 2)")
+
+
+def load_example(file):
+    return yaml.safe_load(open('tests/core/syntax/dtcs/' + file))
+
+
+def test_validation_errors_contain_dtc_name_and_schema_location():
+    with raises(InvalidSchemaError) as err:
+        dtc_dict = load_example('invalid_wrong_version.yml')
+        validate(dtc_dict, 'dtc_name')
+    assert "Error validating data dtc_name with schema blurr/core/syntax/dtc_streaming_schema.yml" in str(
+        err.value)
+
+
+def test_valid_basic_streaming_dtc():
+    dtc_dict = load_example('valid_basic_streaming.yml')
+    validate(dtc_dict)
+
+
+def test_valid_basic_window_dtc():
+    dtc_dict = load_example('valid_basic_window.yml')
+    validate(dtc_dict)
+
+
+def test_invalid_wrong_version():
+    with raises(InvalidSchemaError) as err:
+        dtc_dict = load_example('invalid_wrong_version.yml')
+        validate(dtc_dict)
+    assert "Version: '2088-03-01' not in ('2018-03-01',)" in str(err.value)
+
+
+def test_invalid_string_instead_of_integer():
+    with raises(InvalidSchemaError) as err:
+        dtc_dict = load_example('invalid_string_instead_integer.yml')
+        validate(dtc_dict)
+    assert "Store.ReadWriteUnits: 'five' is not a int." in str(err.value)
+
+
+def test_invalid_non_existing_data_type():
+    with raises(InvalidSchemaError) as err:
+        dtc_dict = load_example('invalid_non_existing_data_type.yml')
+        validate(dtc_dict)
+    assert "Type: 'foo' is not a DTC Valid Data Type." in str(err.value)
+
+
+def test_invalid_incorrect_expression():
+    with raises(InvalidSchemaError) as err:
+        dtc_dict = load_example('invalid_incorrect_expression.yml')
+        validate(dtc_dict)
+    assert "When: 'x == senor roy' is not a Expression." in str(err.value)
+
+
+def test_invalid_datagroup_has_no_fields():
+    with raises(InvalidSchemaError) as err:
+        dtc_dict = load_example('invalid_datagroup_has_no_fields.yml')
+        validate(dtc_dict)
+    assert "DataGroups.0.Fields: Required field missing" in str(err.value)

--- a/tests/runner/data/sample.yml
+++ b/tests/runner/data/sample.yml
@@ -8,10 +8,10 @@ Identity: source.user_id
 Time: parser.parse(source.event_time)
 
 Store:
-   - Type: ProductML:DTC:Storage:DynamoDB
-     Name: dynamo
-     Retention: 180
-     Table: ProductML_Test_Sessions
+  Type: ProductML:DTC:Storage:DynamoDB
+  Name: dynamo
+  Retention: 180
+  Table: ProductML_Test_Sessions
 
 DataGroups:
 

--- a/tests/runner/local_runner_test.py
+++ b/tests/runner/local_runner_test.py
@@ -2,7 +2,8 @@ from blurr.runner.local_runner import LocalRunner
 
 
 def test_local_runner():
-    local_runner = LocalRunner(['tests/runner/data/raw.json'], '', 'tests/runner/data/sample.yml')
+    local_runner = LocalRunner(['tests/runner/data/raw.json'], '',
+                               'tests/runner/data/sample.yml')
     local_runner.execute()
 
     assert local_runner._user_transformer['userA'].snapshot['session'][


### PR DESCRIPTION
This PR is quite simple, but it has too many lines of code. 

Follow this steps and the links to review:

1. I created 2 schemas for [window](https://github.com/productml/blurr/pull/25/files#diff-d6887fb5edf872d26fbdcb075977522e) and [streaming](https://github.com/productml/blurr/pull/25/files#diff-2c67ec53b7caa90910ec3fa170d970c8) DTCs, they define the syntax of the DTCs and are the **single source of truth**
2. The function to trigger a validation, and the validators for custom data types are in [schema_validator.py](https://github.com/productml/blurr/pull/25/files#diff-28edbf32ab28bc0b6f449228c5187fe2)
3. I added many test examples, each DTC in a single file, but all the test cases are together in [schema_validator_test.py](https://github.com/productml/blurr/pull/25/files#diff-3513c8e46a31d25cb77a469df78c2232)
4. I updated [local_runner.py](https://github.com/productml/blurr/pull/25/files#diff-c901f142e80ee676edc3757ab8f20f19) to perform a validation.
5. [BaseSchema](https://github.com/productml/blurr/pull/25/files#diff-df330e71e0842d8336f4280a7b0d54bc) doesn't need to do certain validations anymore, since they're performed previously with the syntax check