### PR TITLE
Remove BaseSchema load methods and do the loading as part of init.

### DIFF
--- a/blurr/core/anchor.py
+++ b/blurr/core/anchor.py
@@ -4,6 +4,7 @@ from typing import Dict, Any
 
 from blurr.core.base import BaseSchema, BaseItem
 from blurr.core.evaluation import Expression, EvaluationContext
+from blurr.core.schema_loader import SchemaLoader
 from blurr.core.session_data_group import SessionDataGroup
 
 
@@ -14,13 +15,13 @@ class AnchorSchema(BaseSchema):
     ATTRIBUTE_CONDITION = 'Condition'
     ATTRIBUTE_MAX = 'Max'
 
-    def load(self) -> None:
+    def __init__(self, fully_qualified_name: str,
+                 schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader)
+
         self.condition = Expression(self._spec[self.ATTRIBUTE_CONDITION])
         self.max = self._spec[
             self.ATTRIBUTE_MAX] if self.ATTRIBUTE_MAX in self._spec else None
-
-    def validate(self, spec: Dict[str, Any]) -> None:
-        self.validate_required_attribute(spec, self.ATTRIBUTE_CONDITION)
 
 
 class Anchor(BaseItem):

--- a/blurr/core/anchor_data_group.py
+++ b/blurr/core/anchor_data_group.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 
 from blurr.core.data_group import DataGroup, DataGroupSchema
 from blurr.core.evaluation import EvaluationContext
+from blurr.core.schema_loader import SchemaLoader
 from blurr.core.store import Store
 from blurr.core.window import Window
 
@@ -13,27 +14,16 @@ class AnchorDataGroupSchema(DataGroupSchema):
     """
     ATTRIBUTE_WINDOW = 'Window'
 
-    def validate(self, spec: Dict[str, Any]):
-        """
-        Overrides the Base Schema validation specifications to include validation for nested schema
-        """
-        # Validate base attributes first
-        super().validate(spec)
+    def __init__(self, fully_qualified_name: str,
+                 schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader)
 
-    def load(self) -> None:
-        """
-        Overrides base load to include loads for nested items
-        """
-        # Loading the base attributes first
-        super().load()
-
+        self.window_schema = None
         if self.ATTRIBUTE_WINDOW in self._spec:
             self.add_window_name()
             self.window_schema = self.schema_loader.get_schema_object(
                 self.fully_qualified_name + '.' +
                 self._spec[self.ATTRIBUTE_WINDOW][self.ATTRIBUTE_NAME])
-        else:
-            self.window_schema = None
 
     def add_window_name(self) -> None:
         if self.ATTRIBUTE_NAME not in self._spec[self.ATTRIBUTE_WINDOW]:

--- a/blurr/core/base.py
+++ b/blurr/core/base.py
@@ -27,29 +27,19 @@ class BaseSchema(ABC):
         """
         self.schema_loader = schema_loader
         self.fully_qualified_name = fully_qualified_name
-        self.__load_spec()
-
-    @abstractmethod
-    def load(self) -> None:
-        """
-        Abstract method placeholder for subclasses to load the spec into the schema
-        """
-        raise NotImplementedError('"load()" must be implemented for a schema.')
-
-    def __load_spec(self) -> None:
-        """
-        Loads the base schema spec into the object
-        """
         self._spec: Dict[str, Any] = self.schema_loader.get_schema_spec(
             self.fully_qualified_name)
+
+        self.extend_schema()
+
         self.name: str = self._spec[self.ATTRIBUTE_NAME]
         self.type: str = self._spec[self.ATTRIBUTE_TYPE]
         self.when: Expression = Expression(
             self._spec[self.ATTRIBUTE_WHEN]
         ) if self.ATTRIBUTE_WHEN in self._spec else None
 
-        # Invokes the loads of the subclass
-        self.load()
+    def extend_schema(self):
+        pass
 
 
 class BaseSchemaCollection(BaseSchema, ABC):
@@ -64,16 +54,9 @@ class BaseSchemaCollection(BaseSchema, ABC):
         :param spec:
         :param nested_schema_attribute:
         """
-        # Must declare all new fields prior to the initialization so that validation can find the new fields
-        self._nested_item_attribute = nested_schema_attribute
-
         super().__init__(fully_qualified_name, schema_loader)
 
-    def load(self) -> None:
-        """
-        Overrides base load to include loads for nested items
-        """
-
+        self._nested_item_attribute = nested_schema_attribute
         # Load nested schema items
         self.nested_schema: Dict[str, Type[BaseSchema]] = {
             schema_spec[self.ATTRIBUTE_NAME]:

--- a/blurr/core/data_group.py
+++ b/blurr/core/data_group.py
@@ -24,13 +24,9 @@ class DataGroupSchema(BaseSchemaCollection, ABC):
         Initializing the nested field schema that all data groups contain
         :param spec: Schema specifications for the field
         """
-        self.store = None
         super().__init__(fully_qualified_name, schema_loader,
                          self.ATTRIBUTE_FIELDS)
-
-    def load(self):
-        super().load()
-
+        self.store = None
         if self.ATTRIBUTE_STORE in self._spec:
             store_fq_name = self.schema_loader.get_fully_qualified_name(
                 self.schema_loader.get_transformer_name(

--- a/blurr/core/field.py
+++ b/blurr/core/field.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 
 from blurr.core.base import BaseSchema, BaseItem
 from blurr.core.evaluation import Expression, EvaluationContext
+from blurr.core.schema_loader import SchemaLoader
 
 
 class FieldSchema(BaseSchema, ABC):
@@ -19,7 +20,9 @@ class FieldSchema(BaseSchema, ABC):
     # Field Name Definitions
     ATTRIBUTE_VALUE = 'Value'
 
-    def load(self) -> None:
+    def __init__(self, fully_qualified_name: str,
+                 schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader)
         self.value: Expression = Expression(self._spec[self.ATTRIBUTE_VALUE])
 
     @property

--- a/blurr/core/streaming_transformer.py
+++ b/blurr/core/streaming_transformer.py
@@ -4,6 +4,7 @@ from blurr.core.base import Expression
 from blurr.core.errors import StreamingSourceNotFoundError
 from blurr.core.evaluation import Context, EvaluationContext
 from blurr.core.record import Record
+from blurr.core.schema_loader import SchemaLoader
 from blurr.core.transformer import Transformer, TransformerSchema
 from blurr.core.store import Store, Key
 from blurr.core.session_data_group import SessionDataGroup
@@ -17,11 +18,10 @@ class StreamingTransformerSchema(TransformerSchema):
     ATTRIBUTE_IDENTITY = 'Identity'
     ATTRIBUTE_TIME = 'Time'
 
-    def load(self) -> None:
-        # Ensure that the base loader is invoked
-        super().load()
+    def __init__(self, fully_qualified_name: str,
+                 schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader)
 
-        # Load the schema specific attributes
         self.identity = Expression(self._spec[self.ATTRIBUTE_IDENTITY])
         self.time = Expression(self._spec[self.ATTRIBUTE_TIME])
 

--- a/blurr/core/transformer.py
+++ b/blurr/core/transformer.py
@@ -25,23 +25,17 @@ class TransformerSchema(BaseSchemaCollection, ABC):
         super().__init__(fully_qualified_name, schema_loader,
                          self.ATTRIBUTE_DATA_GROUPS)
 
-    def load(self) -> None:
-        # Ensure that the base loader is invoked
-        super().load()
-
         # Load the schema specific attributes
         self.version = self._spec[self.ATTRIBUTE_VERSION]
         self.description = self._spec[self.ATTRIBUTE_DESCRIPTION]
 
-        if self.ATTRIBUTE_STORES in self._spec:
-            # Load list of stores from the schema
-            self.stores: Dict[str, Type[Store]] = {
-                schema_spec[self.ATTRIBUTE_NAME]:
-                self.schema_loader.get_nested_schema_object(
-                    self.fully_qualified_name,
-                    schema_spec[self.ATTRIBUTE_NAME])
-                for schema_spec in self._spec[self.ATTRIBUTE_STORES]
-            }
+        # Load list of stores from the schema
+        self.stores: Dict[str, Type[Store]] = {
+            schema_spec[self.ATTRIBUTE_NAME]:
+            self.schema_loader.get_nested_schema_object(
+                self.fully_qualified_name, schema_spec[self.ATTRIBUTE_NAME])
+            for schema_spec in self._spec.get(self.ATTRIBUTE_STORES, [])
+        }
 
         # Load nested schema items
         self.nested_schema: Dict[str, Type[DataGroup]] = {

--- a/blurr/core/window.py
+++ b/blurr/core/window.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, List, Tuple
 
 from blurr.core.base import BaseSchema, BaseItem
 from blurr.core.evaluation import EvaluationContext
+from blurr.core.schema_loader import SchemaLoader
 from blurr.core.session_data_group import SessionDataGroup
 from blurr.core.store import Store, Key
 
@@ -15,14 +16,13 @@ class WindowSchema(BaseSchema):
     ATTRIBUTE_VALUE = 'Value'
     ATTRIBUTE_SOURCE = 'Source'
 
-    def load(self) -> None:
+    def __init__(self, fully_qualified_name: str,
+                 schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader)
+
         self.value = self._spec[self.ATTRIBUTE_VALUE]
         self.source = self.schema_loader.get_schema_object(
             self._spec[self.ATTRIBUTE_SOURCE])
-
-    def validate(self, spec: Dict[str, Any]) -> None:
-        self.validate_required_attribute(spec, self.ATTRIBUTE_VALUE)
-        self.validate_required_attribute(spec, self.ATTRIBUTE_SOURCE)
 
 
 class Window:

--- a/blurr/core/window_transformer.py
+++ b/blurr/core/window_transformer.py
@@ -4,6 +4,7 @@ from blurr.core.anchor import Anchor
 from blurr.core.anchor_data_group import AnchorDataGroup
 from blurr.core.errors import AnchorSessionNotDefinedError
 from blurr.core.evaluation import Context, EvaluationContext
+from blurr.core.schema_loader import SchemaLoader
 from blurr.core.session_data_group import SessionDataGroup
 from blurr.core.store import Store
 from blurr.core.transformer import Transformer, TransformerSchema
@@ -17,16 +18,9 @@ class WindowTransformerSchema(TransformerSchema):
 
     ATTRIBUTE_ANCHOR = 'Anchor'
 
-    def validate(self, spec: Dict[str, Any]) -> None:
-        # Ensure that the base validator is invoked
-        super().validate(spec)
-
-        # Validate schema specific attributes
-        self.validate_required_attribute(spec, self.ATTRIBUTE_ANCHOR)
-
-    def load(self) -> None:
-        # Ensure that the base loader is invoked
-        super().load()
+    def __init__(self, fully_qualified_name: str,
+                 schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader)
 
         # Inject name and type as expected by BaseSchema
         self._spec[self.ATTRIBUTE_ANCHOR][self.ATTRIBUTE_NAME] = 'anchor'


### PR DESCRIPTION
Remove BaseSchema load methods and do the loading as part of init.

This makes the loading more transparent and all instance variables are defined clearly in one place across the layers of abstraction.