### PR TITLE
Executing twine in the same context of pipenv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ jobs:
       - checkout
       - run:
           name: build
-          command: |
-            sh build.sh
+          command: sh build.sh
   deploy:
     docker:
       - image: productml/build-image:fb9ba7674b2590ff5abbd45516b9a27e9dfc5f6d
@@ -23,7 +22,7 @@ jobs:
       - run:
           name: deploy pypi
           command: |
-            sh build.sh
+            pipenv install --dev --ignore-pipfile
             pipenv run python setup.py sdist
             pipenv run python setup.py bdist_wheel
             pipenv run twine upload dist/*


### PR DESCRIPTION
CircleCI can't find twine https://circleci.com/gh/productml/blurr/292

After comparing with [awsfunctions](https://github.com/productml/awsfunctions/blob/master/.circleci/config.yml) I can only think of this difference, perhaps the virtualenvironment is different for a scripts run with `sh`