### PR TITLE
String as default field type when field type is missing

### DIFF
--- a/blurr/core/data_group.py
+++ b/blurr/core/data_group.py
@@ -52,6 +52,11 @@ class DataGroupSchema(BaseSchemaCollection, ABC):
         self.schema_loader.add_schema(identity_field,
                                       self.fully_qualified_name)
 
+        # If field type is missing, set it to string by default
+        for field in spec[self.ATTRIBUTE_FIELDS]:
+            if self.ATTRIBUTE_TYPE not in field:
+                field[self.ATTRIBUTE_TYPE] = 'string'
+
         return super().extend_schema(spec)
 
     @staticmethod

--- a/tests/core/data_group_schema_test.py
+++ b/tests/core/data_group_schema_test.py
@@ -18,6 +18,9 @@ def data_group_schema_spec() -> Dict[str, Any]:
             'Name': 'event_count',
             'Type': 'integer',
             'Value': 5
+        }, {
+            'Name': 'missing_type',
+            'Value': 'test'
         }]
     }
 
@@ -37,7 +40,7 @@ def test_data_group_identity_field(data_group_schema_spec):
     name = schema_loader.add_schema(data_group_schema_spec)
 
     data_group_schema = MockDataGroupSchema(name, schema_loader)
-    assert len(data_group_schema.nested_schema) == 2
+    assert len(data_group_schema.nested_schema) == 3
     assert 'identity' in data_group_schema.nested_schema
 
 
@@ -62,3 +65,14 @@ def test_data_group_schema_initialization_without_store(
     name = schema_loader.add_schema(data_group_schema_spec)
     data_group_schema = MockDataGroupSchema(name, schema_loader)
     assert data_group_schema.store is None
+
+
+def test_field_without_type(data_group_schema_spec):
+    schema_loader = SchemaLoader()
+    del data_group_schema_spec['Store']
+    name = schema_loader.add_schema(data_group_schema_spec)
+    data_group_schema = MockDataGroupSchema(name, schema_loader)
+    missing_type_field = data_group_schema.nested_schema['missing_type']
+
+    assert missing_type_field.type == 'string'
+    assert missing_type_field.type_object is str

--- a/tests/core/data_group_schema_test.py
+++ b/tests/core/data_group_schema_test.py
@@ -13,7 +13,6 @@ def data_group_schema_spec() -> Dict[str, Any]:
     return {
         'Type': 'Blurr:DataGroup:BlockAggregate',
         'Name': 'user',
-        'Store': 'memory',
         'Fields': [{
             'Name': 'event_count',
             'Type': 'integer',
@@ -36,7 +35,6 @@ class MockDataGroupSchema(DataGroupSchema):
 
 def test_data_group_identity_field(data_group_schema_spec):
     schema_loader = SchemaLoader()
-    del data_group_schema_spec['Store']
     name = schema_loader.add_schema(data_group_schema_spec)
 
     data_group_schema = MockDataGroupSchema(name, schema_loader)
@@ -46,6 +44,7 @@ def test_data_group_identity_field(data_group_schema_spec):
 
 def test_data_group_schema_initialization_with_store(data_group_schema_spec,
                                                      store_spec):
+    data_group_schema_spec['Store'] = 'memory'
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(data_group_schema_spec)
     with pytest.raises(
@@ -61,7 +60,6 @@ def test_data_group_schema_initialization_with_store(data_group_schema_spec,
 def test_data_group_schema_initialization_without_store(
         data_group_schema_spec):
     schema_loader = SchemaLoader()
-    del data_group_schema_spec['Store']
     name = schema_loader.add_schema(data_group_schema_spec)
     data_group_schema = MockDataGroupSchema(name, schema_loader)
     assert data_group_schema.store is None
@@ -69,7 +67,6 @@ def test_data_group_schema_initialization_without_store(
 
 def test_field_without_type_defaults_to_string(data_group_schema_spec):
     schema_loader = SchemaLoader()
-    del data_group_schema_spec['Store']
     name = schema_loader.add_schema(data_group_schema_spec)
     data_group_schema = MockDataGroupSchema(name, schema_loader)
     missing_type_field = data_group_schema.nested_schema['missing_type']

--- a/tests/core/data_group_schema_test.py
+++ b/tests/core/data_group_schema_test.py
@@ -67,7 +67,7 @@ def test_data_group_schema_initialization_without_store(
     assert data_group_schema.store is None
 
 
-def test_field_without_type(data_group_schema_spec):
+def test_field_without_type_defaults_to_string(data_group_schema_spec):
     schema_loader = SchemaLoader()
     del data_group_schema_spec['Store']
     name = schema_loader.add_schema(data_group_schema_spec)


### PR DESCRIPTION
Added a schema extension snippet in DataGroup to inject a 'string' Type for fields with missing type.

Fixes #132 