### PR TITLE
Ypaf formatting improvements

### DIFF
--- a/blurr/cli/cli.py
+++ b/blurr/cli/cli.py
@@ -14,5 +14,4 @@ def cli(arguments: Dict[str, Any], out: Out) -> int:
             source = arguments['--source'].split(',')
         elif arguments['<raw-json-files>'] is not None:
             source = arguments['<raw-json-files>'].split(',')
-        return transform(arguments['--streaming-dtc'],
-                         arguments['--window-dtc'], source, out)
+        return transform(arguments['--streaming-dtc'], arguments['--window-dtc'], source, out)

--- a/blurr/cli/transform.py
+++ b/blurr/cli/transform.py
@@ -17,8 +17,7 @@ def transform(stream_dtc_file: Optional[str], window_dtc_file: Optional[str],
                    'the current directory.')
         return 1
 
-    local_runner = LocalRunner(raw_json_files, stream_dtc_file,
-                               window_dtc_file)
+    local_runner = LocalRunner(raw_json_files, stream_dtc_file, window_dtc_file)
     local_runner.execute()
     local_runner.print_output()
 

--- a/blurr/cli/util.py
+++ b/blurr/cli/util.py
@@ -8,7 +8,8 @@ from blurr.core.syntax.schema_validator import is_streaming_dtc, is_window_dtc
 
 def get_yml_files(path: str = '.') -> List[str]:
     return [
-        os.path.join(path, file) for file in os.listdir(path)
+        os.path.join(path, file)
+        for file in os.listdir(path)
         if (file.endswith('.yml') or file.endswith('.yaml'))
     ]
 

--- a/blurr/core/anchor.py
+++ b/blurr/core/anchor.py
@@ -16,18 +16,15 @@ class AnchorSchema(BaseSchema):
     ATTRIBUTE_CONDITION = 'Condition'
     ATTRIBUTE_MAX = 'Max'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
         self.condition = Expression(self._spec[self.ATTRIBUTE_CONDITION])
-        self.max = self._spec[
-            self.ATTRIBUTE_MAX] if self.ATTRIBUTE_MAX in self._spec else None
+        self.max = self._spec[self.ATTRIBUTE_MAX] if self.ATTRIBUTE_MAX in self._spec else None
 
 
 class Anchor(BaseItem):
-    def __init__(self, schema: AnchorSchema,
-                 evaluation_context: EvaluationContext):
+    def __init__(self, schema: AnchorSchema, evaluation_context: EvaluationContext):
         super().__init__(schema, evaluation_context)
         self.condition_met: Dict[datetime, int] = defaultdict(int)
         self.anchor_block = None

--- a/blurr/core/base.py
+++ b/blurr/core/base.py
@@ -18,8 +18,7 @@ class BaseSchema(ABC):
     ATTRIBUTE_TYPE = 'Type'
     ATTRIBUTE_WHEN = 'When'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         """
         Initializes a schema by providing the path to the schema and the schema loader resource
         :param fully_qualified_name: Fully qualified path to the schema
@@ -33,8 +32,7 @@ class BaseSchema(ABC):
         self.name: str = self._spec[self.ATTRIBUTE_NAME]
         self.type: str = self._spec[self.ATTRIBUTE_TYPE]
         self.when: Expression = Expression(
-            self._spec[self.ATTRIBUTE_WHEN]
-        ) if self.ATTRIBUTE_WHEN in self._spec else None
+            self._spec[self.ATTRIBUTE_WHEN]) if self.ATTRIBUTE_WHEN in self._spec else None
 
     def extend_schema(self, spec: Dict[str, Any]) -> Dict[str, Any]:
         """ Extends the defined schema specifications at runtime with defaults """
@@ -59,9 +57,8 @@ class BaseSchemaCollection(BaseSchema, ABC):
         self._nested_item_attribute = nested_schema_attribute
         # Load nested schema items
         self.nested_schema: Dict[str, Type[BaseSchema]] = {
-            schema_spec[self.ATTRIBUTE_NAME]:
-                self.schema_loader.get_nested_schema_object(
-                    self.fully_qualified_name, schema_spec[self.ATTRIBUTE_NAME])
+            schema_spec[self.ATTRIBUTE_NAME]: self.schema_loader.get_nested_schema_object(
+                self.fully_qualified_name, schema_spec[self.ATTRIBUTE_NAME])
             for schema_spec in self._spec[self._nested_item_attribute]
         }
 
@@ -74,8 +71,7 @@ class BaseItem(ABC):
     Base class for for all leaf items that do not contain sub-items
     """
 
-    def __init__(self, schema: BaseSchema,
-                 evaluation_context: EvaluationContext) -> None:
+    def __init__(self, schema: BaseSchema, evaluation_context: EvaluationContext) -> None:
         """
         Initializes an item with the schema and execution context
         :param schema: Schema of the item
@@ -92,8 +88,7 @@ class BaseItem(ABC):
             2. Where WHERE clause is specified and it evaluates to True
         Returns false if a where clause is specified and it evaluates to False
         """
-        return self.schema.when is None or self.schema.when.evaluate(
-            self.evaluation_context)
+        return self.schema.when is None or self.schema.when.evaluate(self.evaluation_context)
 
     @property
     def name(self) -> str:
@@ -131,8 +126,7 @@ class BaseItemCollection(BaseItem):
     Base class for items that contain sub-items within them
     """
 
-    def __init__(self, schema: BaseSchemaCollection,
-                 evaluation_context: EvaluationContext) -> None:
+    def __init__(self, schema: BaseSchemaCollection, evaluation_context: EvaluationContext) -> None:
         """
         Loads nested items to the 'items' collection
         :param schema: Schema that conforms to the item
@@ -158,10 +152,7 @@ class BaseItemCollection(BaseItem):
         """
         try:
 
-            return {
-                name: item.snapshot
-                for name, item in self.nested_items.items()
-            }
+            return {name: item.snapshot for name, item in self.nested_items.items()}
 
         except Exception as e:
             print('Error while creating snapshot for {}', self.name)

--- a/blurr/core/block_data_group.py
+++ b/blurr/core/block_data_group.py
@@ -12,33 +12,28 @@ class BlockDataGroupSchema(DataGroupSchema):
 
     ATTRIBUTE_SPLIT = 'Split'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
         # Load type specific attributes
         self.split: Expression = Expression(
-            self._spec[self.ATTRIBUTE_SPLIT]
-        ) if self.ATTRIBUTE_SPLIT in self._spec else None
+            self._spec[self.ATTRIBUTE_SPLIT]) if self.ATTRIBUTE_SPLIT in self._spec else None
 
     def extend_schema(self, spec: Dict[str, Any]) -> Dict[str, Any]:
         """ Injects the block start and end times """
 
         # Add new fields to the schema spec
-        predefined_field = self._build_time_fields_spec(
-            spec[self.ATTRIBUTE_NAME])
+        predefined_field = self._build_time_fields_spec(spec[self.ATTRIBUTE_NAME])
         spec[self.ATTRIBUTE_FIELDS][0:0] = predefined_field
 
         # Add new field schema to the schema loader
         for field_schema in predefined_field:
-            self.schema_loader.add_schema(field_schema,
-                                          self.fully_qualified_name)
+            self.schema_loader.add_schema(field_schema, self.fully_qualified_name)
 
         return super().extend_schema(spec)
 
     @staticmethod
-    def _build_time_fields_spec(
-            name_in_context: str) -> List[Dict[str, Any]]:
+    def _build_time_fields_spec(name_in_context: str) -> List[Dict[str, Any]]:
         """
         Constructs the spec for predefined fields that are to be included in the master spec prior to schema load
         :param name_in_context: Name of the current object in the context
@@ -48,18 +43,16 @@ class BlockDataGroupSchema(DataGroupSchema):
             {
                 'Name': 'start_time',
                 'Type': 'datetime',
-                'Value': (
-                    'time if {data_group}.start_time is None else time '
-                    'if time < {data_group}.start_time else {data_group}.start_time'
-                ).format(data_group=name_in_context)
+                'Value': ('time if {data_group}.start_time is None else time '
+                          'if time < {data_group}.start_time else {data_group}.start_time'
+                          ).format(data_group=name_in_context)
             },
             {
                 'Name': 'end_time',
                 'Type': 'datetime',
-                'Value': (
-                    'time if {data_group}.end_time is None else time '
-                    'if time > {data_group}.end_time else {data_group}.end_time'
-                ).format(data_group=name_in_context)
+                'Value': ('time if {data_group}.end_time is None else time '
+                          'if time > {data_group}.end_time else {data_group}.end_time'
+                          ).format(data_group=name_in_context)
             },
         ]
 
@@ -75,8 +68,7 @@ class BlockDataGroup(DataGroup):
         """
 
         # If a split is imminent, save the current block snapshot with the timestamp
-        split_should_be_evaluated = not (self.schema.split is None
-                                         or self.start_time is None
+        split_should_be_evaluated = not (self.schema.split is None or self.start_time is None
                                          or self.end_time is None)
 
         if split_should_be_evaluated and self.schema.split.evaluate(

--- a/blurr/core/data_group.py
+++ b/blurr/core/data_group.py
@@ -19,14 +19,12 @@ class DataGroupSchema(BaseSchemaCollection, ABC):
     ATTRIBUTE_STORE = 'Store'
     ATTRIBUTE_FIELDS = 'Fields'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         """
         Initializing the nested field schema that all data groups contain
         :param spec: Schema specifications for the field
         """
-        super().__init__(fully_qualified_name, schema_loader,
-                         self.ATTRIBUTE_FIELDS)
+        super().__init__(fully_qualified_name, schema_loader, self.ATTRIBUTE_FIELDS)
         self.store = None
         if self.ATTRIBUTE_STORE in self._spec:
             self.store = self._load_store(self._spec[self.ATTRIBUTE_STORE])
@@ -37,8 +35,7 @@ class DataGroupSchema(BaseSchemaCollection, ABC):
         :param store_name: The name of the store
         """
         store_fq_name = self.schema_loader.get_fully_qualified_name(
-            self.schema_loader.get_transformer_name(self.fully_qualified_name),
-            store_name)
+            self.schema_loader.get_transformer_name(self.fully_qualified_name), store_name)
         return self.schema_loader.get_schema_object(store_fq_name)
 
     def extend_schema(self, spec: Dict[str, Any]) -> Dict[str, Any]:
@@ -47,8 +44,7 @@ class DataGroupSchema(BaseSchemaCollection, ABC):
         identity_field = {'Name': 'identity', 'Type': 'string', 'Value': 'identity'}
         spec[self.ATTRIBUTE_FIELDS].insert(0, identity_field)
 
-        self.schema_loader.add_schema(identity_field,
-                                      self.fully_qualified_name)
+        self.schema_loader.add_schema(identity_field, self.fully_qualified_name)
 
         # If field type is missing, set it to string by default
         for field in spec[self.ATTRIBUTE_FIELDS]:
@@ -76,8 +72,7 @@ class DataGroup(BaseItemCollection, ABC):
         self.identity = identity
 
         self._fields: Dict[str, Type[BaseItem]] = {
-            name: TypeLoader.load_item(item_schema.type)(
-                item_schema, self.evaluation_context)
+            name: TypeLoader.load_item(item_schema.type)(item_schema, self.evaluation_context)
             for name, item_schema in self.schema.nested_schema.items()
         }
 
@@ -100,5 +95,4 @@ class DataGroup(BaseItemCollection, ABC):
         :param timestamp: Optional timestamp to include in the Key construction
         """
         if self.schema.store:
-            self.schema.store.save(
-                Key(self.identity, self.name, timestamp), self.snapshot)
+            self.schema.store.save(Key(self.identity, self.name, timestamp), self.snapshot)

--- a/blurr/core/evaluation.py
+++ b/blurr/core/evaluation.py
@@ -38,19 +38,15 @@ class Context(dict):
 
 
 class EvaluationContext:
-    def __init__(self,
-                 global_context: Context = None,
-                 local_context: Context = None) -> None:
+    def __init__(self, global_context: Context = None, local_context: Context = None) -> None:
         """
         Initializes an evaluation context with global and local context dictionaries.  The unset parameters default
         to an empty context dictionary.
         :param global_context: Global context dictionary
         :param local_context: Local context dictionary.
         """
-        self.global_context = Context(
-        ) if global_context is None else global_context
-        self.local_context = Context(
-        ) if local_context is None else local_context
+        self.global_context = Context() if global_context is None else global_context
+        self.local_context = Context() if local_context is None else local_context
 
     @property
     def fork(self) -> 'EvaluationContext':
@@ -75,8 +71,7 @@ class EvaluationContext:
         self.global_context[key] = value
 
 
-VALIDATION_INVALID_EQUALS_REGULAR_EXPRESSION = re.compile(
-    '(?:^|[^!=]+)=(?:[^=]+|$)')
+VALIDATION_INVALID_EQUALS_REGULAR_EXPRESSION = re.compile('(?:^|[^!=]+)=(?:[^=]+|$)')
 
 
 class Expression:
@@ -96,8 +91,7 @@ class Expression:
 
         # Validate the expression for errors / unsupported expressions
         if VALIDATION_INVALID_EQUALS_REGULAR_EXPRESSION.findall(code_string):
-            raise InvalidExpressionError(
-                'Modifying value using `=` is not allowed.')
+            raise InvalidExpressionError('Modifying value using `=` is not allowed.')
 
         try:
             self.code_object = compile(self.code_string, '<string>', 'eval')

--- a/blurr/core/field.py
+++ b/blurr/core/field.py
@@ -21,8 +21,7 @@ class FieldSchema(BaseSchema, ABC):
     # Field Name Definitions
     ATTRIBUTE_VALUE = 'Value'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
         self.value: Expression = Expression(self._spec[self.ATTRIBUTE_VALUE])
 
@@ -56,8 +55,7 @@ class Field(BaseItem, ABC):
     An individual field object responsible for retaining the field value
     """
 
-    def __init__(self, schema: FieldSchema,
-                 evaluation_context: EvaluationContext) -> None:
+    def __init__(self, schema: FieldSchema, evaluation_context: EvaluationContext) -> None:
         """
         Initializes the Field with the default for the schema
         :param schema: Field schema
@@ -133,8 +131,7 @@ class ComplexTypeBase(ABC):
 
             # If the method executed is defined in the base type and a base type object is returned
             # (and not the current type), then wrap the base object into an object of the current type
-            if isinstance(result, self_type.__bases__) and not isinstance(
-                    result, self_type):
+            if isinstance(result, self_type.__bases__) and not isinstance(result, self_type):
                 return self_type(result)
                 # TODO This creates a shallow copy of the object - find a way to optimize this
 

--- a/blurr/core/loader.py
+++ b/blurr/core/loader.py
@@ -62,8 +62,7 @@ class TypeLoader:
     def load_type(type_name: str, type_map: dict) -> Any:
         lower_type_name = type_name.lower()
         if lower_type_name not in type_map:
-            raise InvalidSchemaError(
-                'Unknown schema type {}'.format(type_name))
+            raise InvalidSchemaError('Unknown schema type {}'.format(type_name))
         return TypeLoader.import_class_by_full_name(type_map[lower_type_name])
 
     @staticmethod

--- a/blurr/core/record.py
+++ b/blurr/core/record.py
@@ -21,8 +21,7 @@ class Record(dict):
         When attributes are not found, None is returned
         """
         if name.startswith('__') and name.endswith('__'):
-            raise AttributeError(
-                'Record object has no {} attribute.'.format(name))
+            raise AttributeError('Record object has no {} attribute.'.format(name))
         return wrap(self[name]) if name in self else None
 
     def __getitem__(self, item):

--- a/blurr/core/schema_loader.py
+++ b/blurr/core/schema_loader.py
@@ -103,7 +103,8 @@ class SchemaLoader:
         :param type: Schema type.
         :return: List of fully qualified names and schema dictionary tuples.
         """
-        return [(fq_name, schema) for fq_name, schema in self._spec.items()
+        return [(fq_name, schema)
+                for fq_name, schema in self._spec.items()
                 if schema.get(self.ATTRIBUTE_TYPE, '') == type]
 
     @staticmethod

--- a/blurr/core/schema_loader.py
+++ b/blurr/core/schema_loader.py
@@ -16,8 +16,7 @@ class SchemaLoader:
         self._spec = {}
         self._object_cache: Dict[str, 'BaseSchema'] = {}
 
-    def add_schema(self,
-                   spec: Dict[str, Any],
+    def add_schema(self, spec: Dict[str, Any],
                    fully_qualified_parent_name: str = None) -> Optional[str]:
         """
         Add a schema dictionary to the schema loader. The given schema is stored
@@ -72,12 +71,10 @@ class SchemaLoader:
         :return: An initialized schema object of the nested item.
         """
         return self.get_schema_object(
-            self.get_fully_qualified_name(fully_qualified_parent_name,
-                                          nested_item_name))
+            self.get_fully_qualified_name(fully_qualified_parent_name, nested_item_name))
 
     @staticmethod
-    def get_fully_qualified_name(fully_qualified_parent_name: str,
-                                 nested_item_name: str) -> str:
+    def get_fully_qualified_name(fully_qualified_parent_name: str, nested_item_name: str) -> str:
         """
         Returns the fully qualified name by combining the fully_qualified_parent_name
         and nested_item_name.
@@ -97,11 +94,9 @@ class SchemaLoader:
         try:
             return self._spec[fully_qualified_name]
         except:
-            raise InvalidSchemaError(
-                "{} not declared in schema".format(fully_qualified_name))
+            raise InvalidSchemaError("{} not declared in schema".format(fully_qualified_name))
 
-    def get_schemas_of_type(self,
-                            type: str) -> List[Tuple[str, Dict[str, Any]]]:
+    def get_schemas_of_type(self, type: str) -> List[Tuple[str, Dict[str, Any]]]:
         """
         Returns a list of fully qualified names and schema dictionary tuples for
         the schema type provided.

--- a/blurr/core/store.py
+++ b/blurr/core/store.py
@@ -13,8 +13,7 @@ class Key:
     """
     PARTITION = '/'
 
-    def __init__(self, identity: str, group: str,
-                 timestamp: datetime = None) -> None:
+    def __init__(self, identity: str, group: str, timestamp: datetime = None) -> None:
         """
         Initializes a new key for storing data
         :param identity: Primary identity of the record being stored
@@ -36,30 +35,25 @@ class Key:
     def parse(key_string: str) -> 'Key':
         """ Parses a flat key string and returns a key """
         parts = key_string.split(Key.PARTITION)
-        return Key(parts[0], parts[1],
-                   parser.parse(parts[2]) if len(parts) > 2 else None)
+        return Key(parts[0], parts[1], parser.parse(parts[2]) if len(parts) > 2 else None)
 
     def __str__(self):
         """ Returns the string representation of the key"""
         if self.timestamp:
-            return Key.PARTITION.join(
-                [self.identity, self.group,
-                 self.timestamp.isoformat()])
+            return Key.PARTITION.join([self.identity, self.group, self.timestamp.isoformat()])
 
         return Key.PARTITION.join([self.identity, self.group])
 
     def __eq__(self, other: 'Key') -> bool:
-        return (self.identity, self.group,
-                self.timestamp) == (other.identity, other.group,
-                                    other.timestamp)
+        return (self.identity, self.group, self.timestamp) == (other.identity, other.group,
+                                                               other.timestamp)
 
     def __lt__(self, other: 'Key') -> bool:
         """
         Does a less than comparison on two keys. A None timestamp is considered
         larger than a timestamp that has been set.
         """
-        if (self.identity, self.group) != (
-                other.identity, other.group) or self.timestamp is None:
+        if (self.identity, self.group) != (other.identity, other.group) or self.timestamp is None:
             return False
 
         return (other.timestamp is None) or (self.timestamp < other.timestamp)
@@ -69,8 +63,7 @@ class Key:
         Does a greater than comparison on two keys. A None timestamp is
         considered larger than a timestamp that has been set.
         """
-        if (self.identity, self.group) != (
-                other.identity, other.group) or other.timestamp is None:
+        if (self.identity, self.group) != (other.identity, other.group) or other.timestamp is None:
             return False
 
         return (self.timestamp is None) or (self.timestamp > other.timestamp)
@@ -90,8 +83,7 @@ class Store(BaseSchema):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_range(self, start: Key, end: Key = None,
-                  count: int = 0) -> List[Tuple[Key, Any]]:
+    def get_range(self, start: Key, end: Key = None, count: int = 0) -> List[Tuple[Key, Any]]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/blurr/core/streaming_transformer.py
+++ b/blurr/core/streaming_transformer.py
@@ -16,8 +16,7 @@ class StreamingTransformerSchema(TransformerSchema):
     ATTRIBUTE_IDENTITY = 'Identity'
     ATTRIBUTE_TIME = 'Time'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
         self.identity = Expression(self._spec[self.ATTRIBUTE_IDENTITY])
@@ -34,8 +33,8 @@ class StreamingTransformerSchema(TransformerSchema):
         identity = self.identity.evaluate(EvaluationContext(None, context))
         if not identity:
             raise IdentityError(
-                'Could not determine identity using {}. Evaluation context is {}'.
-                format(self.identity.code_string, context))
+                'Could not determine identity using {}. Evaluation context is {}'.format(
+                    self.identity.code_string, context))
         return identity
 
     def get_time(self, context: Context) -> datetime:
@@ -43,8 +42,7 @@ class StreamingTransformerSchema(TransformerSchema):
 
 
 class StreamingTransformer(Transformer):
-    def __init__(self, schema: TransformerSchema, identity: str,
-                 context: Context) -> None:
+    def __init__(self, schema: TransformerSchema, identity: str, context: Context) -> None:
         super().__init__(schema, identity, context)
         self.evaluation_context.global_add('identity', self.identity)
 
@@ -57,16 +55,13 @@ class StreamingTransformer(Transformer):
         """
         # Add source record and time to the global context
         self.evaluation_context.global_add('source', record)
-        self.evaluation_context.global_add('time',
-                                           self.schema.time.evaluate(
-                                               self.evaluation_context))
+        self.evaluation_context.global_add('time', self.schema.time.evaluate(
+            self.evaluation_context))
 
-        record_identity = self.schema.get_identity(
-            self.evaluation_context.global_context)
+        record_identity = self.schema.get_identity(self.evaluation_context.global_context)
         if self.identity != record_identity:
-            raise IdentityError('Identity in transformer (', self.identity,
-                                ') and new record (', record_identity,
-                                ') do not match')
+            raise IdentityError('Identity in transformer (', self.identity, ') and new record (',
+                                record_identity, ') do not match')
 
         self.evaluate()
 

--- a/blurr/core/syntax/schema_validator.py
+++ b/blurr/core/syntax/schema_validator.py
@@ -27,10 +27,7 @@ def is_identifier(s: str) -> bool:
 class DataType(Validator):
     TAG = 'data_type'
 
-    VALUES = [
-        'integer', 'boolean', 'string', 'datetime', 'float', 'map', 'list',
-        'set'
-    ]
+    VALUES = ['integer', 'boolean', 'string', 'datetime', 'float', 'map', 'list', 'set']
 
     def _is_valid(self, value: str) -> bool:
         return value in self.VALUES
@@ -67,8 +64,7 @@ VALIDATORS = {
 
 PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 STREAMING_SCHEMA = yamale.make_schema(
-    os.path.join(PACKAGE_DIR, 'dtc_streaming_schema.yml'),
-    validators=VALIDATORS)
+    os.path.join(PACKAGE_DIR, 'dtc_streaming_schema.yml'), validators=VALIDATORS)
 
 WINDOW_SCHEMA = yamale.make_schema(
     os.path.join(PACKAGE_DIR, 'dtc_window_schema.yml'), validators=VALIDATORS)

--- a/blurr/core/transformer.py
+++ b/blurr/core/transformer.py
@@ -21,29 +21,24 @@ class TransformerSchema(BaseSchemaCollection, ABC):
     ATTRIBUTE_STORES = 'Stores'
     ATTRIBUTE_DATA_GROUPS = 'DataGroups'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
-        super().__init__(fully_qualified_name, schema_loader,
-                         self.ATTRIBUTE_DATA_GROUPS)
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
+        super().__init__(fully_qualified_name, schema_loader, self.ATTRIBUTE_DATA_GROUPS)
 
         # Load the schema specific attributes
         self.version = self._spec[self.ATTRIBUTE_VERSION]
         self.description = self._spec[
-            self.
-            ATTRIBUTE_DESCRIPTION] if self.ATTRIBUTE_DESCRIPTION in self._spec else None
+            self.ATTRIBUTE_DESCRIPTION] if self.ATTRIBUTE_DESCRIPTION in self._spec else None
 
         # Load list of stores from the schema
         self.stores: Dict[str, Type[Store]] = {
-            schema_spec[self.ATTRIBUTE_NAME]:
-            self.schema_loader.get_nested_schema_object(
+            schema_spec[self.ATTRIBUTE_NAME]: self.schema_loader.get_nested_schema_object(
                 self.fully_qualified_name, schema_spec[self.ATTRIBUTE_NAME])
             for schema_spec in self._spec.get(self.ATTRIBUTE_STORES, [])
         }
 
         # Load nested schema items
         self.nested_schema: Dict[str, Type[DataGroup]] = {
-            schema_spec[self.ATTRIBUTE_NAME]:
-            self.schema_loader.get_nested_schema_object(
+            schema_spec[self.ATTRIBUTE_NAME]: self.schema_loader.get_nested_schema_object(
                 self.fully_qualified_name, schema_spec[self.ATTRIBUTE_NAME])
             for schema_spec in self._spec[self._nested_item_attribute]
         }
@@ -55,13 +50,12 @@ class Transformer(BaseItemCollection, ABC):
     to the context
     """
 
-    def __init__(self, schema: TransformerSchema, identity: str,
-                 context: Context) -> None:
+    def __init__(self, schema: TransformerSchema, identity: str, context: Context) -> None:
         super().__init__(schema, EvaluationContext(global_context=context))
         # Load the nested items into the item
         self._data_groups: Dict[str, Type[BaseItem]] = {
-            name: TypeLoader.load_item(item_schema.type)(
-                item_schema, identity, self.evaluation_context)
+            name: TypeLoader.load_item(item_schema.type)(item_schema, identity,
+                                                         self.evaluation_context)
             for name, item_schema in schema.nested_schema.items()
         }
         self.identity = identity

--- a/blurr/core/window_data_group.py
+++ b/blurr/core/window_data_group.py
@@ -18,13 +18,11 @@ class WindowDataGroupSchema(DataGroupSchema):
     ATTRIBUTE_WINDOW_TYPE = 'WindowType'
     ATTRIBUTE_SOURCE = 'Source'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
         self.window_value = self._spec[self.ATTRIBUTE_WINDOW_VALUE]
         self.window_type = self._spec[self.ATTRIBUTE_WINDOW_TYPE]
-        self.source = self.schema_loader.get_schema_object(
-            self._spec[self.ATTRIBUTE_SOURCE])
+        self.source = self.schema_loader.get_schema_object(self._spec[self.ATTRIBUTE_SOURCE])
 
 
 class _WindowSource:
@@ -61,23 +59,20 @@ class WindowDataGroup(DataGroup):
             self.window_source.view = self._load_blocks(
                 store.get_range(
                     Key(self.identity, self.schema.source.name, start_time),
-                    Key(self.identity, self.schema.source.name,
-                        self._get_end_time(start_time))))
+                    Key(self.identity, self.schema.source.name, self._get_end_time(start_time))))
         else:
             self.window_source.view = self._load_blocks(
                 store.get_range(
-                    Key(self.identity, self.schema.source.name, start_time),
-                    None, self.schema.window_value))
+                    Key(self.identity, self.schema.source.name, start_time), None,
+                    self.schema.window_value))
 
         self._validate_view()
 
     def _validate_view(self):
-        if self.schema.window_type == 'count' and len(
-                self.window_source.view) != abs(self.schema.window_value):
-            raise PrepareWindowMissingBlocksError(
-                'Expecting {} but not found {} blocks'.format(
-                    abs(self.schema.window_value),
-                    len(self.window_source.view)))
+        if self.schema.window_type == 'count' and len(self.window_source.view) != abs(
+                self.schema.window_value):
+            raise PrepareWindowMissingBlocksError('Expecting {} but not found {} blocks'.format(
+                abs(self.schema.window_value), len(self.window_source.view)))
 
         if len(self.window_source.view) == 0:
             raise PrepareWindowMissingBlocksError('No matching blocks found')
@@ -104,8 +99,7 @@ class WindowDataGroup(DataGroup):
         :return: List of BlockDataGroup
         """
         return [
-            BlockDataGroup(self.schema.source, self.identity,
-                           EvaluationContext()).restore(block)
+            BlockDataGroup(self.schema.source, self.identity, EvaluationContext()).restore(block)
             for (_, block) in blocks
         ]
 

--- a/blurr/core/window_transformer.py
+++ b/blurr/core/window_transformer.py
@@ -18,18 +18,15 @@ class WindowTransformerSchema(TransformerSchema):
 
     ATTRIBUTE_ANCHOR = 'Anchor'
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
         # Inject name and type as expected by BaseSchema
         self._spec[self.ATTRIBUTE_ANCHOR][self.ATTRIBUTE_NAME] = 'anchor'
         self._spec[self.ATTRIBUTE_ANCHOR][self.ATTRIBUTE_TYPE] = 'anchor'
-        self.schema_loader.add_schema(self._spec[self.ATTRIBUTE_ANCHOR],
-                                      self.fully_qualified_name)
+        self.schema_loader.add_schema(self._spec[self.ATTRIBUTE_ANCHOR], self.fully_qualified_name)
 
-        self.anchor = self.schema_loader.get_schema_object(
-            self.fully_qualified_name + '.anchor')
+        self.anchor = self.schema_loader.get_schema_object(self.fully_qualified_name + '.anchor')
 
 
 class WindowTransformer(Transformer):
@@ -38,11 +35,9 @@ class WindowTransformer(Transformer):
     block data.
     """
 
-    def __init__(self, schema: WindowTransformerSchema, identity: str,
-                 context: Context) -> None:
+    def __init__(self, schema: WindowTransformerSchema, identity: str, context: Context) -> None:
         super().__init__(schema, identity, context)
-        self.anchor = Anchor(
-            schema.anchor, EvaluationContext(global_context=context))
+        self.anchor = Anchor(schema.anchor, EvaluationContext(global_context=context))
 
     def evaluate_anchor(self, block: BlockDataGroup) -> bool:
         """
@@ -51,8 +46,7 @@ class WindowTransformer(Transformer):
         :return: True, if the anchor condition is met, otherwise, False.
         """
         # Set up context so that anchor can process the block
-        self.evaluation_context.local_context.add(
-            block.schema.fully_qualified_name, block)
+        self.evaluation_context.local_context.add(block.schema.fully_qualified_name, block)
         if self.anchor.evaluate_anchor(block):
 
             try:
@@ -97,7 +91,6 @@ class WindowTransformer(Transformer):
             if isinstance(v, dict):
                 flattened_dict.update(self._flatten_snapshot(k, v))
             else:
-                flattened_dict[prefix + '.' + k
-                               if prefix is not None else k] = v
+                flattened_dict[prefix + '.' + k if prefix is not None else k] = v
 
         return flattened_dict

--- a/blurr/runner/local_runner.py
+++ b/blurr/runner/local_runner.py
@@ -28,8 +28,7 @@ class LocalRunner:
         self._schema_loader = SchemaLoader()
 
         self._stream_dtc = yaml.safe_load(open(stream_dtc_file))
-        self._stream_dtc_name = self._schema_loader.add_schema(
-            self._stream_dtc)
+        self._stream_dtc_name = self._schema_loader.add_schema(self._stream_dtc)
         self._stream_transformer_schema = self._schema_loader.get_schema_object(
             self._stream_dtc_name)
 
@@ -62,8 +61,8 @@ class LocalRunner:
 
     def execute_for_all_users(self) -> None:
         for identity, events in self._user_events.items():
-            block_data, window_data = execute_dtc(
-                events, identity, self._stream_dtc, self._window_dtc)
+            block_data, window_data = execute_dtc(events, identity, self._stream_dtc,
+                                                  self._window_dtc)
 
             self._block_data.update(block_data)
             self._window_data[identity] = window_data
@@ -96,8 +95,7 @@ class LocalRunner:
 
 def main():
     arguments = docopt(__doc__, version='pre-alpha')
-    local_runner = LocalRunner(arguments['--raw-data'].split(','),
-                               arguments['--streaming-dtc'],
+    local_runner = LocalRunner(arguments['--raw-data'].split(','), arguments['--streaming-dtc'],
                                arguments['--window-dtc'])
     local_runner.execute()
     if arguments['--output-file'] is None:

--- a/blurr/runner/spark_runner.py
+++ b/blurr/runner/spark_runner.py
@@ -32,10 +32,9 @@ class SparkRunner:
 
         self._schema_loader = SchemaLoader()
         self._stream_dtc = yaml.safe_load(open(stream_dtc_file))
-        self._stream_dtc_name = self._schema_loader.add_schema(
-            self._stream_dtc)
-        self._stream_transformer_schema = StreamingTransformerSchema(
-            self._stream_dtc_name, self._schema_loader)
+        self._stream_dtc_name = self._schema_loader.add_schema(self._stream_dtc)
+        self._stream_transformer_schema = StreamingTransformerSchema(self._stream_dtc_name,
+                                                                     self._schema_loader)
 
         self._window_dtc = None if window_dtc_file is None else yaml.safe_load(
             open(window_dtc_file))
@@ -47,42 +46,35 @@ class SparkRunner:
         if self._window_dtc is not None:
             validate(self._window_dtc)
 
-    def execute_per_user_events(
-            self, user_events: Tuple[str, List[Tuple[datetime, Record]]]
-    ) -> Union[List[Tuple[Key, Any]], List[Dict]]:
+    def execute_per_user_events(self, user_events: Tuple[str, List[Tuple[datetime, Record]]]
+                                ) -> Union[List[Tuple[Key, Any]], List[Dict]]:
         identity = user_events[0]
         events = user_events[1]
-        block_data, window_data = identity_runner.execute_dtc(
-            events, identity, self._stream_dtc, self._window_dtc)
+        block_data, window_data = identity_runner.execute_dtc(events, identity, self._stream_dtc,
+                                                              self._window_dtc)
         if self._window_dtc is None:
             return block_data
         else:
             return window_data
 
-    def get_per_user_records(
-            self, event_str: str) -> Tuple[str, Tuple[datetime, Record]]:
+    def get_per_user_records(self, event_str: str) -> Tuple[str, Tuple[datetime, Record]]:
         record = Record(json.loads(event_str))
         source_context = Context({'source': record})
         source_context.add('parser', parser)
         return (self._stream_transformer_schema.get_identity(source_context),
-                (self._stream_transformer_schema.get_time(source_context),
-                 record))
+                (self._stream_transformer_schema.get_time(source_context), record))
 
     def execute(self, spark_context: SparkContext) -> RDD:
         raw_records = spark_context.union(
             [spark_context.textFile(file) for file in self._raw_files])
         per_user_records = raw_records.map(
-            lambda x: self.get_per_user_records(x)).groupByKey().mapValues(
-                list)
+            lambda x: self.get_per_user_records(x)).groupByKey().mapValues(list)
 
-        return per_user_records.flatMap(
-            lambda x: self.execute_per_user_events(x))
+        return per_user_records.flatMap(lambda x: self.execute_per_user_events(x))
 
-    def write_output_file(self, spark: SparkBlock, path: str,
-                          per_user_data: RDD) -> None:
+    def write_output_file(self, spark: SparkBlock, path: str, per_user_data: RDD) -> None:
         if self._window_dtc is None:
-            per_user_data.map(
-                lambda x: json.dumps(x, default=str)).saveAsTextFile(path)
+            per_user_data.map(lambda x: json.dumps(x, default=str)).saveAsTextFile(path)
         else:
             # Convert to a DataFrame first so that the data can be saved as a CSV
             spark.createDataFrame(per_user_data).write.csv(path, header=True)
@@ -90,8 +82,7 @@ class SparkRunner:
 
 def main():
     arguments = docopt(__doc__, version='pre-alpha')
-    spark_runner = SparkRunner(arguments['--raw-data'].split(','),
-                               arguments['--streaming-dtc'],
+    spark_runner = SparkRunner(arguments['--raw-data'].split(','), arguments['--streaming-dtc'],
                                arguments['--window-dtc'])
 
     spark = SparkBlock \
@@ -100,8 +91,7 @@ def main():
         .getOrCreate()
     spark_context = spark.sparkContext
     per_user_data_rdd = spark_runner.execute(spark_context)
-    spark_runner.write_output_file(spark, arguments['--output-file'],
-                                   per_user_data_rdd)
+    spark_runner.write_output_file(spark, arguments['--output-file'], per_user_data_rdd)
 
 
 if __name__ == "__main__":

--- a/blurr/store/memory_store.py
+++ b/blurr/store/memory_store.py
@@ -9,8 +9,7 @@ class MemoryStore(Store):
     In-memory store implementation
     """
 
-    def __init__(self, fully_qualified_name: str,
-                 schema_loader: SchemaLoader) -> None:
+    def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
         self._cache: Dict[Key, Any] = dict()
 
@@ -23,8 +22,7 @@ class MemoryStore(Store):
     def get_all(self) -> List[Tuple[Key, Any]]:
         return [(k, v) for (k, v) in self._cache.items()]
 
-    def get_range(self, start: Key, end: Key = None,
-                  count: int = 0) -> List[Tuple[Key, Any]]:
+    def get_range(self, start: Key, end: Key = None, count: int = 0) -> List[Tuple[Key, Any]]:
         if end and count:
             raise ValueError('Only one of `end` or `count` can be set')
 
@@ -32,11 +30,9 @@ class MemoryStore(Store):
             start, end = end, start
 
         if not count:
-            return [(key, item) for key, item in self._cache.items()
-                    if start < key < end]
+            return [(key, item) for key, item in self._cache.items() if start < key < end]
         else:
-            filter_condition = (lambda i: i[0] > start) if count > 0 else (
-                lambda i: i[0] < start)
+            filter_condition = (lambda i: i[0] > start) if count > 0 else (lambda i: i[0] < start)
 
             items = sorted(filter(filter_condition, list(self._cache.items())))
 

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ pipenv install --dev --ignore-pipfile
 
 
 echo "formatting and validating code..."
-pipenv run yapf -i -r . --style='{allow_split_before_dict_value : false}'
+pipenv run yapf -i -r .
 # TODO: fix mypy errors
 # pipenv run mypy blurr/*/*.py --ignore-missing-imports --disallow-untyped-defs --disallow-untyped-calls
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[yapf]
+based_on_style = pep8
+spaces_before_comment = 4
+column_limit = 100
+allow_split_before_dict_value = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 based_on_style = pep8
 column_limit = 100
 allow_split_before_dict_value = false
+split_complex_comprehension = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [yapf]
 based_on_style = pep8
-spaces_before_comment = 4
 column_limit = 100
 allow_split_before_dict_value = false

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,7 @@ version_file.close()
 setup(
     name=name(),
     version=version(),
-    description=
-    "Data aggregation pipeline for running real-time predictive models",
+    description="Data aggregation pipeline for running real-time predictive models",
     long_description=readme(),
     long_description_content_type='text/markdown',
     author="productml.com",
@@ -63,8 +62,8 @@ setup(
     url="https://github.com/productml/blurr",
     packages=find_packages(),
     data_files=[
-        "blurr/core/syntax/dtc_window_schema.yml",
-        "blurr/core/syntax/dtc_streaming_schema.yml", "blurr/VERSION"
+        "blurr/core/syntax/dtc_window_schema.yml", "blurr/core/syntax/dtc_streaming_schema.yml",
+        "blurr/VERSION"
     ],
     include_package_data=True,
     install_requires=requirements(),

--- a/tests/cli/cli_validate_test.py
+++ b/tests/cli/cli_validate_test.py
@@ -9,9 +9,7 @@ from tests.cli.out_stub import OutStub
 def run_command(dtc_files: List[str], out: OutStub) -> int:
     arguments = {
         'validate': True,
-        '<DTC>': [
-            'tests/core/syntax/dtcs/' + dtc_file for dtc_file in dtc_files
-        ]
+        '<DTC>': ['tests/core/syntax/dtcs/' + dtc_file for dtc_file in dtc_files]
     }
     return cli(arguments, out)
 
@@ -44,8 +42,7 @@ def test_multiple_dtc_files(out):
     assert code == 1
     assert get_running_validation_str('invalid_yaml.yml') in out.stdout
     assert 'document is valid' in out.stdout
-    assert get_running_validation_str(
-        'valid_basic_streaming.yml') in out.stdout
+    assert get_running_validation_str('valid_basic_streaming.yml') in out.stdout
     assert 'invalid yaml' in out.stderr
 
 
@@ -54,5 +51,4 @@ def test_invalid_dtc(out):
     assert code == 1
     assert 'Error validating data dtc with schema' in out.stderr
     assert 'Version: \'2088-03-01\' not in (\'2018-03-01\',)' in out.stderr
-    assert get_running_validation_str(
-        'invalid_wrong_version.yml') in out.stdout
+    assert get_running_validation_str('invalid_wrong_version.yml') in out.stdout

--- a/tests/cli/transform_test.py
+++ b/tests/cli/transform_test.py
@@ -7,8 +7,7 @@ from blurr.cli.transform import transform
 
 
 def run_command(stream_dtc_file: Optional[str], window_dtc_file: Optional[str],
-                source: Optional[str], raw_json_files: Optional[str],
-                out: Out) -> int:
+                source: Optional[str], raw_json_files: Optional[str], out: Out) -> int:
     return cli({
         'transform': True,
         'validate': False,
@@ -47,8 +46,7 @@ def test_transform_no_raw_data(capsys) -> None:
 
 
 def test_transform_only_stream(capsys) -> None:
-    assert run_command('tests/data/stream.yml', None, 'tests/data/raw.json',
-                       None, Out()) == 0
+    assert run_command('tests/data/stream.yml', None, 'tests/data/raw.json', None, Out()) == 0
     out, err = capsys.readouterr()
     assert_record_in_ouput(('userA/session/2018-03-07T22:35:31+00:00', {
         'identity': 'userA',
@@ -76,8 +74,7 @@ def test_transform_only_stream(capsys) -> None:
 
 def test_transform_valid_raw_with_source(capsys) -> None:
     assert run_command('tests/data/stream.yml', 'tests/data/window.yml',
-                       'tests/data/raw.json,tests/data/raw.json', None,
-                       Out()) == 0
+                       'tests/data/raw.json,tests/data/raw.json', None, Out()) == 0
     out, err = capsys.readouterr()
     assert_record_in_ouput(('userA', [{
         'last_session.identity': 'userA',

--- a/tests/cli/util_test.py
+++ b/tests/cli/util_test.py
@@ -40,13 +40,10 @@ def override_listdir(path: str) -> Any:
 @mock.patch('os.listdir', new=override_listdir)
 def test_get_yml_files():
     assert get_yml_files() == []
-    assert sorted(get_yml_files('path1')) == sorted([
-        os.path.join('path1', 'file1.yml'),
-        os.path.join('path1', 'file3.yaml')
-    ])
-    assert get_yml_files('path/inner_path') == [
-        os.path.join('path/inner_path', 'file1.yml')
-    ]
+    assert sorted(get_yml_files('path1')) == sorted(
+        [os.path.join('path1', 'file1.yml'),
+         os.path.join('path1', 'file3.yaml')])
+    assert get_yml_files('path/inner_path') == [os.path.join('path/inner_path', 'file1.yml')]
 
 
 @mock.patch('builtins.open', new=override_open)
@@ -57,18 +54,15 @@ def test_get_stream_window_dtc_files_bad_files():
 
 @mock.patch('builtins.open', new=override_open)
 def test_get_stream_window_dtc_files_missing_stream():
-    assert get_stream_window_dtc_files(
-        ['invalid.yml', 'stream1.yml']) == ('stream1.yml', None)
+    assert get_stream_window_dtc_files(['invalid.yml', 'stream1.yml']) == ('stream1.yml', None)
 
 
 @mock.patch('builtins.open', new=override_open)
 def test_get_stream_window_dtc_files_missing_window():
-    assert get_stream_window_dtc_files(
-        ['invalid.yml', 'window2.yml']) == (None, 'window2.yml')
+    assert get_stream_window_dtc_files(['invalid.yml', 'window2.yml']) == (None, 'window2.yml')
 
 
 @mock.patch('builtins.open', new=override_open)
 def test_get_stream_window_dtc_files_valid():
-    assert get_stream_window_dtc_files(
-        ['stream1.yml', 'stream2.yml', 'window1.yml']) == ('stream1.yml',
-                                                           'window1.yml')
+    assert get_stream_window_dtc_files(['stream1.yml', 'stream2.yml',
+                                        'window1.yml']) == ('stream1.yml', 'window1.yml')

--- a/tests/core/anchor_test.py
+++ b/tests/core/anchor_test.py
@@ -63,16 +63,14 @@ def block_item(block_schema: BlockDataGroupSchema) -> BlockDataGroup:
     return block
 
 
-def test_anchor_max_one(anchor_schema_max_one: AnchorSchema,
-                        block_item: BlockDataGroup) -> None:
+def test_anchor_max_one(anchor_schema_max_one: AnchorSchema, block_item: BlockDataGroup) -> None:
     anchor = Anchor(anchor_schema_max_one, EvaluationContext())
     assert anchor.evaluate_anchor(block_item) is True
     anchor.add_condition_met()
     assert anchor.evaluate_anchor(block_item) is False
 
 
-def test_anchor_max_two(anchor_schema_max_two: AnchorSchema,
-                        block_item: BlockDataGroup) -> None:
+def test_anchor_max_two(anchor_schema_max_two: AnchorSchema, block_item: BlockDataGroup) -> None:
     anchor = Anchor(anchor_schema_max_two, EvaluationContext())
     assert anchor.evaluate_anchor(block_item) is True
     anchor.add_condition_met()
@@ -92,13 +90,11 @@ def test_anchor_max_not_specified(anchor_schema_max_one: AnchorSchema,
     assert anchor.evaluate_anchor(block_item) is True
 
 
-def test_anchor_condition(anchor_schema_max_one: AnchorSchema,
-                          block_item: BlockDataGroup) -> None:
+def test_anchor_condition(anchor_schema_max_one: AnchorSchema, block_item: BlockDataGroup) -> None:
     anchor_schema_max_one.condition = Expression('session.events > 3')
     eval_context = EvaluationContext()
     anchor = Anchor(anchor_schema_max_one, eval_context)
-    eval_context.local_context.add(block_item.schema.fully_qualified_name,
-                                   block_item)
+    eval_context.local_context.add(block_item.schema.fully_qualified_name, block_item)
     assert anchor.evaluate_anchor(block_item) is False
 
     block_item.restore({

--- a/tests/core/base_schema_test.py
+++ b/tests/core/base_schema_test.py
@@ -38,8 +38,7 @@ def get_test_schema(schema_spec: Dict[str, Any]) -> TestSchema:
     return TestSchema(name, schema_loader)
 
 
-def test_base_schema_with_all_attributes(
-        test_schema_spec: Dict[str, Any]) -> None:
+def test_base_schema_with_all_attributes(test_schema_spec: Dict[str, Any]) -> None:
     test_schema = get_test_schema(test_schema_spec)
     assert test_schema.name == test_schema_spec[BaseSchema.ATTRIBUTE_NAME]
     assert test_schema.type == test_schema_spec[BaseSchema.ATTRIBUTE_TYPE]
@@ -47,8 +46,7 @@ def test_base_schema_with_all_attributes(
     assert test_schema.when.evaluate(EvaluationContext())
 
 
-def test_base_schema_with_no_attribute_when(
-        test_schema_spec: Dict[str, Any]) -> None:
+def test_base_schema_with_no_attribute_when(test_schema_spec: Dict[str, Any]) -> None:
     del test_schema_spec[BaseSchema.ATTRIBUTE_WHEN]
     test_schema = get_test_schema(test_schema_spec)
     assert test_schema.name == test_schema_spec[BaseSchema.ATTRIBUTE_NAME]

--- a/tests/core/block_data_group_schema_test.py
+++ b/tests/core/block_data_group_schema_test.py
@@ -55,8 +55,7 @@ def test_block_data_group_schema_initialization(block_data_group_schema_spec):
     assert match_fields(loader_spec['Fields'])
 
 
-def test_block_data_group_schema_with_split_initialization(
-        block_data_group_schema_spec):
+def test_block_data_group_schema_with_split_initialization(block_data_group_schema_spec):
     block_data_group_schema_spec['Split'] = '4 > 2'
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(block_data_group_schema_spec)

--- a/tests/core/block_data_group_test.py
+++ b/tests/core/block_data_group_test.py
@@ -37,8 +37,7 @@ def schema_loader(store_spec) -> SchemaLoader:
     return schema_loader
 
 
-def check_fields(fields: Dict[str, Field],
-                 expected_field_values: Dict[str, Any]) -> bool:
+def check_fields(fields: Dict[str, Field], expected_field_values: Dict[str, Any]) -> bool:
     if len(fields) != len(expected_field_values):
         return False
 
@@ -54,35 +53,31 @@ def check_fields(fields: Dict[str, Field],
 def create_block_data_group(schema, time, identity) -> BlockDataGroup:
     evaluation_context = EvaluationContext()
     block_data_group = BlockDataGroup(
-        schema=schema,
-        identity=identity,
-        evaluation_context=evaluation_context)
+        schema=schema, identity=identity, evaluation_context=evaluation_context)
     evaluation_context.global_add('time', time)
     evaluation_context.global_add('user', block_data_group)
     evaluation_context.global_add('identity', identity)
     return block_data_group
 
 
-def test_block_data_group_schema_evaluate_without_split(
-        block_data_group_schema_spec, schema_loader):
+def test_block_data_group_schema_evaluate_without_split(block_data_group_schema_spec,
+                                                        schema_loader):
     name = schema_loader.add_schema(block_data_group_schema_spec)
     block_data_group_schema = BlockDataGroupSchema(name, schema_loader)
 
     identity = 'userA'
     time = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
-    block_data_group = create_block_data_group(block_data_group_schema, time,
-                                               identity)
+    block_data_group = create_block_data_group(block_data_group_schema, time, identity)
     block_data_group.evaluate()
 
     # Check eval results of various fields
     assert len(block_data_group.nested_items) == 4
-    assert check_fields(
-        block_data_group.nested_items, {
-            'identity': identity,
-            'event_count': 1,
-            'start_time': time,
-            'end_time': time
-        })
+    assert check_fields(block_data_group.nested_items, {
+        'identity': identity,
+        'event_count': 1,
+        'start_time': time,
+        'end_time': time
+    })
 
     # aggregate snapshot should not exist in store
     assert block_data_group_schema.store.get(
@@ -91,42 +86,37 @@ def test_block_data_group_schema_evaluate_without_split(
             timestamp=block_data_group.start_time)) is None
 
 
-def test_block_data_group_schema_evaluate_with_split(
-        block_data_group_schema_spec, schema_loader):
+def test_block_data_group_schema_evaluate_with_split(block_data_group_schema_spec, schema_loader):
     block_data_group_schema_spec['Split'] = 'user.event_count == 2'
     name = schema_loader.add_schema(block_data_group_schema_spec)
     block_data_group_schema = BlockDataGroupSchema(name, schema_loader)
 
     identity = 'userA'
     time = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
-    block_data_group = create_block_data_group(block_data_group_schema, time,
-                                               identity)
+    block_data_group = create_block_data_group(block_data_group_schema, time, identity)
     block_data_group.evaluate()
     block_data_group.evaluate()
 
     # Check eval results of various fields before split
-    assert check_fields(
-        block_data_group.nested_items, {
-            'identity': identity,
-            'event_count': 2,
-            'start_time': time,
-            'end_time': time
-        })
+    assert check_fields(block_data_group.nested_items, {
+        'identity': identity,
+        'event_count': 2,
+        'start_time': time,
+        'end_time': time
+    })
 
     current_snapshot = block_data_group.snapshot
     block_data_group.evaluate()
 
     # Check eval results of various fields
-    assert check_fields(
-        block_data_group.nested_items, {
-            'identity': identity,
-            'event_count': 1,
-            'start_time': time,
-            'end_time': time
-        })
+    assert check_fields(block_data_group.nested_items, {
+        'identity': identity,
+        'event_count': 1,
+        'start_time': time,
+        'end_time': time
+    })
 
     # Check aggregate snapshot present in store
     assert block_data_group_schema.store.get(
-        Key(identity=block_data_group.identity,
-            group=block_data_group.name,
+        Key(identity=block_data_group.identity, group=block_data_group.name,
             timestamp=time)) == current_snapshot

--- a/tests/core/complex_fields_test.py
+++ b/tests/core/complex_fields_test.py
@@ -92,19 +92,16 @@ def schema_loader() -> SchemaLoader:
 
 
 @fixture(scope='module')
-def data_group_schema(
-        schema_loader: SchemaLoader,
-        data_group_schema_spec: Dict[str, Any]) -> DataGroupSchema:
-    return VariableDataGroupSchema(
-        schema_loader.add_schema(data_group_schema_spec), schema_loader)
+def data_group_schema(schema_loader: SchemaLoader,
+                      data_group_schema_spec: Dict[str, Any]) -> DataGroupSchema:
+    return VariableDataGroupSchema(schema_loader.add_schema(data_group_schema_spec), schema_loader)
 
 
 @fixture
 def data_group(data_group_schema: DataGroupSchema) -> DataGroup:
     context = EvaluationContext()
 
-    dg = VariableDataGroup(
-        schema=data_group_schema, identity="12345", evaluation_context=context)
+    dg = VariableDataGroup(schema=data_group_schema, identity="12345", evaluation_context=context)
     context.global_add('test', dg)
 
     return dg

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -30,51 +30,22 @@ def schema_loader_with_mem_store(stream_dtc_name: str) -> SchemaLoader:
 
 
 def init_memory_store(store: MemoryStore) -> None:
-    store.save(
-        Key('user1', 'state'), {
-            'variable_1': 1,
-            'variable_a': 'a',
-            'variable_true': True
-        })
+    store.save(Key('user1', 'state'), {'variable_1': 1, 'variable_a': 'a', 'variable_true': True})
 
     date = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
-    store.save(
-        Key('user1', 'session', date), {
-            'events': 1,
-            'start_time': date
-        })
+    store.save(Key('user1', 'session', date), {'events': 1, 'start_time': date})
 
     date = datetime(2018, 3, 7, 20, 35, 35, 0, timezone.utc)
-    store.save(
-        Key('user1', 'session', date), {
-            'events': 2,
-            'start_time': date
-        })
+    store.save(Key('user1', 'session', date), {'events': 2, 'start_time': date})
 
     date = datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc)
-    store.save(
-        Key('user1', 'session', date), {
-            'events': 3,
-            'start_time': date
-        })
+    store.save(Key('user1', 'session', date), {'events': 3, 'start_time': date})
 
     date = datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc)
-    store.save(
-        Key('user1', 'session', date), {
-            'events': 4,
-            'start_time': date
-        })
+    store.save(Key('user1', 'session', date), {'events': 4, 'start_time': date})
 
     date = datetime(2018, 3, 7, 23, 40, 31, 0, timezone.utc)
-    store.save(
-        Key('user1', 'session', date), {
-            'events': 5,
-            'start_time': date
-        })
+    store.save(Key('user1', 'session', date), {'events': 5, 'start_time': date})
 
     date = datetime(2018, 3, 8, 23, 40, 31, 0, timezone.utc)
-    store.save(
-        Key('user1', 'session', date), {
-            'events': 6,
-            'start_time': date
-        })
+    store.save(Key('user1', 'session', date), {'events': 6, 'start_time': date})

--- a/tests/core/data_group_schema_test.py
+++ b/tests/core/data_group_schema_test.py
@@ -42,13 +42,11 @@ def test_data_group_schema_contains_identity_field(data_group_schema_spec):
     assert 'identity' in data_group_schema.nested_schema
 
 
-def test_data_group_schema_initialization_with_store(data_group_schema_spec,
-                                                     store_spec):
+def test_data_group_schema_initialization_with_store(data_group_schema_spec, store_spec):
     data_group_schema_spec['Store'] = 'memory'
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(data_group_schema_spec)
-    with pytest.raises(
-            InvalidSchemaError, match="user.memory not declared in schema"):
+    with pytest.raises(InvalidSchemaError, match="user.memory not declared in schema"):
         MockDataGroupSchema(name, schema_loader)
 
     schema_loader.add_schema(store_spec, 'user')
@@ -57,8 +55,7 @@ def test_data_group_schema_initialization_with_store(data_group_schema_spec,
     assert data_group_schema.store.name == 'memory'
 
 
-def test_data_group_schema_initialization_without_store(
-        data_group_schema_spec):
+def test_data_group_schema_initialization_without_store(data_group_schema_spec):
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(data_group_schema_spec)
     data_group_schema = MockDataGroupSchema(name, schema_loader)

--- a/tests/core/data_group_test.py
+++ b/tests/core/data_group_test.py
@@ -40,8 +40,7 @@ def data_group_schema_with_store():
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(get_data_group_schema_spec())
     schema_loader.add_schema(get_store_spec(), 'user')
-    return MockDataGroupSchema(
-        fully_qualified_name=name, schema_loader=schema_loader)
+    return MockDataGroupSchema(fully_qualified_name=name, schema_loader=schema_loader)
 
 
 @fixture
@@ -50,8 +49,7 @@ def data_group_schema_without_store():
     data_group_schema_spec = get_data_group_schema_spec()
     del data_group_schema_spec['Store']
     name = schema_loader.add_schema(data_group_schema_spec)
-    return MockDataGroupSchema(
-        fully_qualified_name=name, schema_loader=schema_loader)
+    return MockDataGroupSchema(fully_qualified_name=name, schema_loader=schema_loader)
 
 
 def test_data_group_initialization(data_group_schema_with_store):
@@ -103,7 +101,6 @@ def test_data_group_finalize(data_group_schema_with_store):
         identity="12345",
         evaluation_context=EvaluationContext())
     data_group.finalize()
-    snapshot_data_group = data_group.schema.store.get(
-        Key(identity="12345", group="user"))
+    snapshot_data_group = data_group.schema.store.get(Key(identity="12345", group="user"))
     assert snapshot_data_group is not None
     assert snapshot_data_group == data_group.snapshot

--- a/tests/core/expression_test.py
+++ b/tests/core/expression_test.py
@@ -39,17 +39,8 @@ def test_expression_globals_locals() -> None:
     assert expr.evaluate(EvaluationContext()) is None
 
     assert expr.evaluate(EvaluationContext(Context({'a': 2, 'b': 3}))) == 6
-    assert expr.evaluate(
-        EvaluationContext(local_context=Context({
-            'a': 2,
-            'b': 3
-        }))) == 6
-    assert expr.evaluate(
-        EvaluationContext(Context({
-            'a': 2
-        }), Context({
-            'b': 3
-        }))) == 6
+    assert expr.evaluate(EvaluationContext(local_context=Context({'a': 2, 'b': 3}))) == 6
+    assert expr.evaluate(EvaluationContext(Context({'a': 2}), Context({'b': 3}))) == 6
 
 
 def test_expression_conditional() -> None:
@@ -65,10 +56,7 @@ def test_expression_user_function() -> None:
         return 3 > 4
 
     expr = Expression(code_string)
-    assert expr.evaluate(
-        EvaluationContext(Context({
-            'test_function': test_function
-        }))) == 3
+    assert expr.evaluate(EvaluationContext(Context({'test_function': test_function}))) == 3
 
 
 def test_invalid_expression() -> None:
@@ -117,42 +105,26 @@ def test_validate_valid() -> None:
 
 
 def test_validate_invalid() -> None:
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('a= b')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('a!=b = ')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression(' =a')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('b =')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('b &= c')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('b += c')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('b |= c')
 
-    with raises(
-            InvalidExpressionError,
-            message='Modifying value using `=` is not allowed.'):
+    with raises(InvalidExpressionError, message='Modifying value using `=` is not allowed.'):
         Expression('b /= c')

--- a/tests/core/field_test.py
+++ b/tests/core/field_test.py
@@ -12,11 +12,7 @@ from blurr.core.simple_fields import SimpleField, BooleanFieldSchema, IntegerFie
 @fixture
 def test_field_schema() -> Dict[str, Any]:
     schema_loader = SchemaLoader()
-    name = schema_loader.add_schema({
-        'Name': 'max_attempts',
-        'Type': 'integer',
-        'Value': 5
-    })
+    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': 5})
     return MockFieldSchema(name, schema_loader)
 
 
@@ -63,11 +59,7 @@ def test_field_evaluate_without_needs_evaluation():
 
 def test_field_evaluate_incorrect_typecast():
     schema_loader = SchemaLoader()
-    name = schema_loader.add_schema({
-        'Name': 'max_attempts',
-        'Type': 'integer',
-        'Value': '"Hi"'
-    })
+    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': '"Hi"'})
     field_schema = IntegerFieldSchema(name, schema_loader)
     field = SimpleField(field_schema, EvaluationContext())
     with pytest.raises(ValueError):
@@ -76,11 +68,7 @@ def test_field_evaluate_incorrect_typecast():
 
 def test_field_evaluate_implicit_typecast_integer():
     schema_loader = SchemaLoader()
-    name = schema_loader.add_schema({
-        'Name': 'max_attempts',
-        'Type': 'integer',
-        'Value': '23.45'
-    })
+    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': '23.45'})
     field_schema = IntegerFieldSchema(name, schema_loader)
     field = SimpleField(field_schema, EvaluationContext())
     field.evaluate()
@@ -90,11 +78,7 @@ def test_field_evaluate_implicit_typecast_integer():
 
 def test_field_evaluate_implicit_typecast_float():
     schema_loader = SchemaLoader()
-    name = schema_loader.add_schema({
-        'Name': 'max_attempts',
-        'Type': 'float',
-        'Value': '23'
-    })
+    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'float', 'Value': '23'})
     field_schema = FloatFieldSchema(name, schema_loader)
     field = SimpleField(field_schema, EvaluationContext())
     field.evaluate()
@@ -104,11 +88,7 @@ def test_field_evaluate_implicit_typecast_float():
 
 def test_field_evaluate_implicit_typecast_bool():
     schema_loader = SchemaLoader()
-    name = schema_loader.add_schema({
-        'Name': 'max_attempts',
-        'Type': 'boolean',
-        'Value': '1+2'
-    })
+    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'boolean', 'Value': '1+2'})
     field_schema = BooleanFieldSchema(name, schema_loader)
     field = SimpleField(field_schema, EvaluationContext())
     field.evaluate()

--- a/tests/core/key_test.py
+++ b/tests/core/key_test.py
@@ -22,8 +22,8 @@ def test_invalid_group():
 
 
 def test_parse():
-    assert Key.parse('a/b/2018-03-07T22:35:31+00:00') == Key(
-        'a', 'b', datetime(2018, 3, 7, 22, 35, 31))
+    assert Key.parse('a/b/2018-03-07T22:35:31+00:00') == Key('a', 'b',
+                                                             datetime(2018, 3, 7, 22, 35, 31))
     assert Key.parse('a/b') == Key('a', 'b', None)
     with pytest.raises(Exception):
         Key.parse('')
@@ -39,19 +39,17 @@ def test_equals():
     assert Key('a', 'b') == Key('a', 'b')
     assert Key('a', 'b') != Key('a', 'c')
     assert Key('a', 'b') != Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31))
-    assert Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) == Key(
-        'a', 'b', datetime(2018, 3, 7, 22, 35, 31))
-    assert Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) != Key(
-        'a', 'b', datetime(2018, 3, 6, 22, 35, 31))
+    assert Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) == Key('a', 'b',
+                                                                  datetime(2018, 3, 7, 22, 35, 31))
+    assert Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) != Key('a', 'b',
+                                                                  datetime(2018, 3, 6, 22, 35, 31))
 
 
 def test_greater_than():
     assert (Key('a', 'b') > Key('a', 'b')) is False
     assert (Key('a', 'b') > Key('a', 'c')) is False
-    assert (Key('a', 'b') > Key('a', 'b', datetime(2018, 3, 7, 22, 35,
-                                                   31))) is True
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key(
-        'a', 'b')) is False
+    assert (Key('a', 'b') > Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is True
+    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key('a', 'b')) is False
     assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key(
         'a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is False
     assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key(
@@ -63,10 +61,8 @@ def test_greater_than():
 def test_less_than():
     assert (Key('a', 'b') < Key('a', 'b')) is False
     assert (Key('a', 'b') < Key('a', 'c')) is False
-    assert (Key('a', 'b') < Key('a', 'b', datetime(2018, 3, 7, 22, 35,
-                                                   31))) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key('a',
-                                                                  'b')) is True
+    assert (Key('a', 'b') < Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is False
+    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key('a', 'b')) is True
     assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key(
         'a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is False
     assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key(

--- a/tests/core/record_test.py
+++ b/tests/core/record_test.py
@@ -25,12 +25,7 @@ def test_array() -> None:
 
 
 def test_complex_array() -> None:
-    record = Record({
-        'complex_array_field': [{
-            'field_1': 'one',
-            'field_2': 2
-        }, ['one', 'two'], 1]
-    })
+    record = Record({'complex_array_field': [{'field_1': 'one', 'field_2': 2}, ['one', 'two'], 1]})
     assert len(record.complex_array_field) == 3
     assert record.complex_array_field[0].field_1 == 'one'
     assert record.complex_array_field[1][0] == 'one'
@@ -53,6 +48,5 @@ def test_getattr():
     # Defined class attributes work as expected.
     assert record.__class__ == Record
     # Un-defined class attributes throw exception.
-    with pytest.raises(
-            AttributeError, match='Record object has no __test__ attribute.'):
+    with pytest.raises(AttributeError, match='Record object has no __test__ attribute.'):
         record.__test__

--- a/tests/core/schema_loader_test.py
+++ b/tests/core/schema_loader_test.py
@@ -88,22 +88,19 @@ def test_add_valid_nested_schema(nested_schema_spec_bad_type: Dict) -> None:
     schema_loader = SchemaLoader()
 
     assert schema_loader.add_schema(nested_schema_spec_bad_type) == 'test'
-    assert schema_loader.get_schema_spec(
-        'test.test_group') == nested_schema_spec_bad_type['DataGroups'][0]
-    assert schema_loader.get_schema_spec(
-        'test.test_group.country') == nested_schema_spec_bad_type[
-            'DataGroups'][0]['Fields'][0]
-    assert schema_loader.get_schema_spec(
-        'test.test_group.events') == nested_schema_spec_bad_type['DataGroups'][
-            0]['Fields'][1]
+    assert schema_loader.get_schema_spec('test.test_group') == nested_schema_spec_bad_type[
+        'DataGroups'][0]
+    assert schema_loader.get_schema_spec('test.test_group.country') == nested_schema_spec_bad_type[
+        'DataGroups'][0]['Fields'][0]
+    assert schema_loader.get_schema_spec('test.test_group.events') == nested_schema_spec_bad_type[
+        'DataGroups'][0]['Fields'][1]
 
 
 def test_get_schema_object_error(nested_schema_spec_bad_type: Dict) -> None:
     schema_loader = SchemaLoader()
     schema_loader.add_schema(nested_schema_spec_bad_type)
 
-    with pytest.raises(
-            InvalidSchemaError, match='Unknown schema type Blurr:Unknown'):
+    with pytest.raises(InvalidSchemaError, match='Unknown schema type Blurr:Unknown'):
         schema_loader.get_schema_object('test')
 
     with pytest.raises(InvalidSchemaError, match='Type not defined in schema'):
@@ -111,17 +108,14 @@ def test_get_schema_object_error(nested_schema_spec_bad_type: Dict) -> None:
 
 
 def test_get_schema_object(schema_loader: SchemaLoader) -> None:
-    assert isinstance(
-        schema_loader.get_schema_object('test'),
-        StreamingTransformerSchema) is True
+    assert isinstance(schema_loader.get_schema_object('test'), StreamingTransformerSchema) is True
     field_schema = schema_loader.get_schema_object('test.test_group.events')
     assert isinstance(field_schema, IntegerFieldSchema) is True
 
     # Assert that the same object is returned and a new one is not created.
     assert field_schema.when is None
     field_schema.when = 'True'
-    assert schema_loader.get_schema_object(
-        'test.test_group.events').when == 'True'
+    assert schema_loader.get_schema_object('test.test_group.events').when == 'True'
 
 
 def test_get_nested_schema_object(schema_loader: SchemaLoader):
@@ -131,15 +125,12 @@ def test_get_nested_schema_object(schema_loader: SchemaLoader):
 
 
 def test_get_fully_qualified_name() -> None:
-    assert SchemaLoader.get_fully_qualified_name('parent',
-                                                 'child') == 'parent.child'
+    assert SchemaLoader.get_fully_qualified_name('parent', 'child') == 'parent.child'
 
 
-def test_get_schemas_of_type(schema_loader: SchemaLoader,
-                             nested_schema_spec: Dict) -> None:
+def test_get_schemas_of_type(schema_loader: SchemaLoader, nested_schema_spec: Dict) -> None:
     assert schema_loader.get_schemas_of_type('integer') == [
-        ('test.test_group.events',
-         nested_schema_spec['DataGroups'][0]['Fields'][1])
+        ('test.test_group.events', nested_schema_spec['DataGroups'][0]['Fields'][1])
     ]
 
 

--- a/tests/core/store_test.py
+++ b/tests/core/store_test.py
@@ -8,29 +8,20 @@ from blurr.store.memory_store import MemoryStore
 
 
 @fixture
-def memory_store(schema_loader_with_mem_store, stream_dtc_name,
-                 mem_store_name) -> MemoryStore:
-    return schema_loader_with_mem_store.get_schema_object(
-        stream_dtc_name + '.' + mem_store_name)
+def memory_store(schema_loader_with_mem_store, stream_dtc_name, mem_store_name) -> MemoryStore:
+    return schema_loader_with_mem_store.get_schema_object(stream_dtc_name + '.' + mem_store_name)
 
 
 @fixture
 def empty_memory_store() -> MemoryStore:
     schema_loader = SchemaLoader()
-    schema_loader.add_schema({
-        'Name': 'memstore',
-        'Type': 'Blurr:Store:MemoryStore'
-    })
+    schema_loader.add_schema({'Name': 'memstore', 'Type': 'Blurr:Store:MemoryStore'})
     return MemoryStore('memstore', schema_loader)
 
 
 def test_get(memory_store: MemoryStore) -> None:
     key = Key('user1', 'state')
-    assert memory_store.get(key) == {
-        'variable_1': 1,
-        'variable_a': 'a',
-        'variable_true': True
-    }
+    assert memory_store.get(key) == {'variable_1': 1, 'variable_a': 'a', 'variable_true': True}
 
     date = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
     key = Key('user1', 'session', date)
@@ -64,35 +55,28 @@ def test_get_range_start_end(memory_store: MemoryStore) -> None:
     """
     Tests that the range get does not include the blocks that lie on the boundary
     """
-    start = Key('user1', 'session',
-                datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
-    end = Key('user1', 'session',
-              datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
+    start = Key('user1', 'session', datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
+    end = Key('user1', 'session', datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
     blocks = memory_store.get_range(start, end)
     assert len(blocks) == 2
-    assert blocks[0][1]['start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0,
-                                                  timezone.utc)
+    assert blocks[0][1]['start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0, timezone.utc)
 
 
 def test_get_range_start_count(memory_store: MemoryStore) -> None:
     """
     Tests that the range get does not include the blocks that lie on the boundary
     """
-    start = Key('user1', 'session',
-                datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
+    start = Key('user1', 'session', datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
     blocks = memory_store.get_range(start, None, 2)
     assert len(blocks) == 2
-    assert blocks[0][1]['start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0,
-                                                  timezone.utc)
+    assert blocks[0][1]['start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0, timezone.utc)
 
 
 def test_get_range_end_count(memory_store: MemoryStore) -> None:
     """
     Tests that the range get does not include the blocks that lie on the boundary
     """
-    end = Key('user1', 'session',
-              datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
+    end = Key('user1', 'session', datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
     blocks = memory_store.get_range(end, None, -2)
     assert len(blocks) == 2
-    assert blocks[0][1]['start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0,
-                                                  timezone.utc)
+    assert blocks[0][1]['start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0, timezone.utc)

--- a/tests/core/window_data_group_schema_test.py
+++ b/tests/core/window_data_group_schema_test.py
@@ -6,9 +6,8 @@ from blurr.core.schema_loader import SchemaLoader
 from blurr.core.window_data_group import WindowDataGroupSchema
 
 
-def test_initialization_with_valid_source(
-        schema_loader_with_mem_store: SchemaLoader, mem_store_name: str,
-        stream_dtc_name: str):
+def test_initialization_with_valid_source(schema_loader_with_mem_store: SchemaLoader,
+                                          mem_store_name: str, stream_dtc_name: str):
     schema_loader_with_mem_store.add_schema({
         'Type': 'Blurr:DataGroup:BlockAggregate',
         'Name': 'session',
@@ -34,16 +33,15 @@ def test_initialization_with_valid_source(
         }]
     })
 
-    window_data_group_schema = WindowDataGroupSchema(
-        name, schema_loader_with_mem_store)
+    window_data_group_schema = WindowDataGroupSchema(name, schema_loader_with_mem_store)
     assert window_data_group_schema.window_type == 'day'
     assert window_data_group_schema.window_value == 1
     assert isinstance(window_data_group_schema.source, BlockDataGroupSchema)
     assert window_data_group_schema.source.name == 'session'
 
 
-def test_initialization_with_invalid_source(
-        schema_loader_with_mem_store: SchemaLoader, stream_dtc_name: str):
+def test_initialization_with_invalid_source(schema_loader_with_mem_store: SchemaLoader,
+                                            stream_dtc_name: str):
 
     name = schema_loader_with_mem_store.add_schema({
         'Type': 'ProductML:DTC:DataGroup:WindowAggregate',
@@ -58,7 +56,5 @@ def test_initialization_with_invalid_source(
         }]
     })
 
-    with raises(
-            InvalidSchemaError,
-            match=stream_dtc_name + '.session not declared in schema'):
+    with raises(InvalidSchemaError, match=stream_dtc_name + '.session not declared in schema'):
         WindowDataGroupSchema(name, schema_loader_with_mem_store)

--- a/tests/core/window_data_group_test.py
+++ b/tests/core/window_data_group_test.py
@@ -10,8 +10,7 @@ from blurr.core.window_data_group import WindowDataGroupSchema, WindowDataGroup
 
 
 @fixture
-def window_data_group_schema(schema_loader_with_mem_store: SchemaLoader,
-                             mem_store_name: str,
+def window_data_group_schema(schema_loader_with_mem_store: SchemaLoader, mem_store_name: str,
                              stream_dtc_name: str) -> WindowDataGroupSchema:
     schema_loader_with_mem_store.add_schema({
         'Type': 'Blurr:DataGroup:BlockAggregate',
@@ -42,108 +41,86 @@ def window_data_group_schema(schema_loader_with_mem_store: SchemaLoader,
 
 
 @fixture
-def window_data_group(
-        window_data_group_schema: WindowDataGroupSchema) -> WindowDataGroup:
-    return WindowDataGroup(window_data_group_schema, "user1",
-                           EvaluationContext())
+def window_data_group(window_data_group_schema: WindowDataGroupSchema) -> WindowDataGroup:
+    return WindowDataGroup(window_data_group_schema, "user1", EvaluationContext())
 
 
 def test_window_type_day_positive(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'day'
     window_data_group.schema.window_value = 1
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [4, 5]
 
 
 def test_window_type_day_negative(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'day'
     window_data_group.schema.window_value = -1
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [1, 2]
 
 
-def test_window_type_day_zero_value(
-        window_data_group: WindowDataGroup) -> None:
+def test_window_type_day_zero_value(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'day'
     window_data_group.schema.window_value = 0
-    with pytest.raises(
-            PrepareWindowMissingBlocksError, match='No matching blocks found'):
-        window_data_group.prepare_window(
-            datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    with pytest.raises(PrepareWindowMissingBlocksError, match='No matching blocks found'):
+        window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == []
 
 
 def test_window_type_hour_positive(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'hour'
     window_data_group.schema.window_value = 1
-    with pytest.raises(
-            PrepareWindowMissingBlocksError, match='No matching blocks found'):
-        window_data_group.prepare_window(
-            datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    with pytest.raises(PrepareWindowMissingBlocksError, match='No matching blocks found'):
+        window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == []
 
     window_data_group.schema.window_type = 'hour'
     window_data_group.schema.window_value = 2
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [4]
 
 
 def test_window_type_hour_negative(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'hour'
     window_data_group.schema.window_value = -24
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [1, 2]
 
 
-def test_window_type_hour_zero_value(
-        window_data_group: WindowDataGroup) -> None:
+def test_window_type_hour_zero_value(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'hour'
     window_data_group.schema.window_value = 0
-    with pytest.raises(
-            PrepareWindowMissingBlocksError, match='No matching blocks found'):
-        window_data_group.prepare_window(
-            datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    with pytest.raises(PrepareWindowMissingBlocksError, match='No matching blocks found'):
+        window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == []
 
 
-def test_window_type_count_positive(
-        window_data_group: WindowDataGroup) -> None:
+def test_window_type_count_positive(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'count'
     window_data_group.schema.window_value = -1
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [2]
 
 
-def test_window_type_count_negative(
-        window_data_group: WindowDataGroup) -> None:
+def test_window_type_count_negative(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'count'
     window_data_group.schema.window_value = 1
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [4]
 
 
-def test_window_type_count_missing_sesssions(
-        window_data_group: WindowDataGroup) -> None:
+def test_window_type_count_missing_sesssions(window_data_group: WindowDataGroup) -> None:
     window_data_group.schema.window_type = 'count'
     window_data_group.schema.window_value = 20
     with pytest.raises(
-            PrepareWindowMissingBlocksError,
-            match='Expecting 20 but not found 3 blocks'):
-        window_data_group.prepare_window(
-            datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+            PrepareWindowMissingBlocksError, match='Expecting 20 but not found 3 blocks'):
+        window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     assert window_data_group.window_source.events == [4, 5, 6]
 
 
 def test_evaluate(window_data_group):
     window_data_group.schema.window_type = 'day'
     window_data_group.schema.window_value = 1
-    window_data_group.prepare_window(
-        datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
+    window_data_group.prepare_window(datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc))
     window_data_group.evaluate()
     assert window_data_group.total_events == 9

--- a/tests/core/window_transformer_test.py
+++ b/tests/core/window_transformer_test.py
@@ -29,11 +29,10 @@ def test_window_transformer(test_stream_schema_spec, test_window_schema_spec):
     init_memory_store(schema_loader.get_schema_object('Sessions.memory'))
 
     window_transformer = WindowTransformer(
-        WindowTransformerSchema(window_dtc_name, schema_loader), 'user1',
-        Context())
+        WindowTransformerSchema(window_dtc_name, schema_loader), 'user1', Context())
     block = BlockDataGroup(
-        BlockDataGroupSchema(stream_dtc_name + '.session', schema_loader),
-        'user1', EvaluationContext())
+        BlockDataGroupSchema(stream_dtc_name + '.session', schema_loader), 'user1',
+        EvaluationContext())
     block.restore({
         'events': 3,
         'start_time': datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc),

--- a/tests/extended/extended_test.py
+++ b/tests/extended/extended_test.py
@@ -5,8 +5,7 @@ from blurr.runner.local_runner import LocalRunner
 
 
 def test_extended_runner():
-    local_runner = LocalRunner(['tests/extended/raw.json'],
-                               'tests/extended/stream.yml')
+    local_runner = LocalRunner(['tests/extended/raw.json'], 'tests/extended/stream.yml')
     local_runner.execute()
 
     assert len(local_runner._block_data) == 5
@@ -46,9 +45,8 @@ def test_extended_runner():
     }
     assert result_session == expected_session
 
-    result_session_10 = local_runner._block_data[Key('user-1', 'session',
-                                                     datetime(
-                                                         2016, 2, 10, 0, 0))]
+    result_session_10 = local_runner._block_data[Key('user-1', 'session', datetime(
+        2016, 2, 10, 0, 0))]
     expected_session_10 = {
         'identity': 'user-1',
         'start_time': datetime(2016, 2, 10, 0, 0),
@@ -66,9 +64,8 @@ def test_extended_runner():
 
     assert result_session_10 == expected_session_10
 
-    result_session_11 = local_runner._block_data[Key('user-1', 'session',
-                                                     datetime(
-                                                         2016, 2, 11, 0, 0))]
+    result_session_11 = local_runner._block_data[Key('user-1', 'session', datetime(
+        2016, 2, 11, 0, 0))]
     expected_session_11 = {
         'identity': 'user-1',
         'start_time': datetime(2016, 2, 11, 0, 0),
@@ -86,9 +83,8 @@ def test_extended_runner():
 
     assert result_session_11 == expected_session_11
 
-    result_session_12 = local_runner._block_data[Key('user-1', 'session',
-                                                     datetime(
-                                                         2016, 2, 12, 0, 0))]
+    result_session_12 = local_runner._block_data[Key('user-1', 'session', datetime(
+        2016, 2, 12, 0, 0))]
     expected_session_12 = {
         'identity': 'user-1',
         'start_time': datetime(2016, 2, 12, 0, 0),

--- a/tests/runner/local_runner_test.py
+++ b/tests/runner/local_runner_test.py
@@ -7,8 +7,7 @@ from blurr.runner.local_runner import LocalRunner
 
 
 def test_local_runner_stream_only():
-    local_runner = LocalRunner(['tests/data/raw.json'],
-                               'tests/data/stream.yml', None)
+    local_runner = LocalRunner(['tests/data/raw.json'], 'tests/data/stream.yml', None)
     local_runner.execute()
 
     assert len(local_runner._block_data) == 7
@@ -53,8 +52,7 @@ def test_local_runner_stream_only():
 
 
 def test_local_runner_no_vars_stored():
-    local_runner = LocalRunner(['tests/data/raw.json'],
-                               'tests/data/stream.yml', None)
+    local_runner = LocalRunner(['tests/data/raw.json'], 'tests/data/stream.yml', None)
     local_runner.execute()
 
     # Variables should not be stored
@@ -62,8 +60,7 @@ def test_local_runner_no_vars_stored():
 
 
 def test_local_runner_with_window():
-    local_runner = LocalRunner(['tests/data/raw.json'],
-                               'tests/data/stream.yml',
+    local_runner = LocalRunner(['tests/data/raw.json'], 'tests/data/stream.yml',
                                'tests/data/window.yml')
     local_runner.execute()
 


### PR DESCRIPTION
Created setup.cfg file to add the YAPF configurations there instead of the build file.

Removed style declaration from the build file.

Formatting changes:
- Column Width increased to 100 from default 79
- Enabled splitting complex comprehensions
