### PR TITLE
Use compile for expression validation as opposed to ast.parse.

### DIFF
--- a/blurr/store/memory_store.py
+++ b/blurr/store/memory_store.py
@@ -40,8 +40,7 @@ class MemoryStore(Store):
                     items_in_range.append((key, item))
                 elif key.timestamp is None:
                     item_ts = item.get('_start_time', datetime.min)
-                    item_ts = item_ts if  item_ts.tzinfo else item_ts.replace(
-                        tzinfo=timezone.utc)
+                    item_ts = item_ts if item_ts.tzinfo else item_ts.replace(tzinfo=timezone.utc)
                     if start.timestamp < item_ts < end.timestamp:
                         items_in_range.append((key, item))
                         continue

--- a/tests/core/expression_test.py
+++ b/tests/core/expression_test.py
@@ -116,6 +116,14 @@ def test_execution_key_error(caplog) -> None:
     assert caplog.records[0].levelno == logging.DEBUG
 
 
+def test_execution_error_type_mismatch(caplog) -> None:
+    caplog.set_level(logging.DEBUG)
+    code_string = '1 + \'a\''
+    assert Expression(code_string).evaluate(EvaluationContext(Context({'test_dict': {}}))) is None
+    assert 'TypeError in evaluating expression 1 + \'a\'' in caplog.records[0].message
+    assert caplog.records[0].levelno == logging.DEBUG
+
+
 def test_execution_error_missing_data_group(caplog, schema_loader: SchemaLoader) -> None:
     caplog.set_level(logging.DEBUG)
     context = Context({

--- a/tests/core/syntax/dtcs/invalid_datagroup_has_no_fields.yml
+++ b/tests/core/syntax/dtcs/invalid_datagroup_has_no_fields.yml
@@ -3,7 +3,7 @@ Version: '2018-03-01'
 Description: Example
 Name: example_name
 Identity: source.user_id
-When: source.package_version = '1.0'
+When: source.package_version == '1.0'
 Stores:
  - Type: Blurr:Store:MemoryStore
    Name: memory_store

--- a/tests/core/syntax/dtcs/invalid_missing_time.yml
+++ b/tests/core/syntax/dtcs/invalid_missing_time.yml
@@ -3,7 +3,7 @@ Version: '2018-03-01'
 Description: Example
 Name: example_name
 Identity: source.user_id
-When: source.package_version = '1.0'
+When: source.package_version == '1.0'
 Stores:
  - Type: Blurr:Store:MemoryStore
    Name: memory_store
@@ -17,4 +17,4 @@ DataGroups:
        Atomic: true
      - Name: country
        Value: source.country
-       When: last_session = None
+       When: last_session == None

--- a/tests/core/syntax/dtcs/invalid_non_existing_data_type.yml
+++ b/tests/core/syntax/dtcs/invalid_non_existing_data_type.yml
@@ -3,7 +3,7 @@ Version: '2018-03-01'
 Description: Example
 Name: example_name
 Identity: source.user_id
-When: source.package_version = '1.0'
+When: source.package_version == '1.0'
 Stores:
  - Type: Blurr:Store:MemoryStore
    Name: memory_store

--- a/tests/core/syntax/dtcs/invalid_set_expression.yml
+++ b/tests/core/syntax/dtcs/invalid_set_expression.yml
@@ -1,0 +1,22 @@
+Type: Blurr:Streaming
+Version: '2018-03-01'
+Description: Example
+Name: example_name
+Time: time
+Identity: source.user_id
+
+
+# SHOULD BE A CORRECT PYTHON EXPRESSION
+When: x = 'test'
+
+
+Stores:
+ - Type: Blurr:Store:MemoryStore
+   Name: memory_store
+DataGroups:
+ - Type: Blurr:DataGroup:IdentityAggregate
+   Name: user
+   Store: offer_ai_dynamo
+   Fields:
+     - Name: user_id
+       Value: source.customer_identifier

--- a/tests/core/syntax/dtcs/invalid_string_instead_integer.yml
+++ b/tests/core/syntax/dtcs/invalid_string_instead_integer.yml
@@ -3,7 +3,7 @@ Version: '2018-03-01'
 Description: Example
 SourceDTC: test
 Name: example_name
-When: source.package_version = '1.0'
+When: source.package_version == '1.0'
 
 Anchor:
   Condition: True==True

--- a/tests/core/syntax/dtcs/invalid_yaml.yml
+++ b/tests/core/syntax/dtcs/invalid_yaml.yml
@@ -4,7 +4,7 @@ Type: Blurr:Streaming
       Description: Example
 Name: example_name
 Identity: source.user_id
-When: source.package_version = '1.0'
+When: source.package_version == '1.0'
 Store:
             Type: Blurr:Storage:DynamoDB
    Name: offer_ai_dynamo

--- a/tests/core/syntax/schema_validator_test.py
+++ b/tests/core/syntax/schema_validator_test.py
@@ -47,7 +47,7 @@ def load_example(file):
 
 
 def test_validation_errors_contain_dtc_name_and_schema_location():
-    with raises(InvalidSchemaError, match='Error validating data dtc_name with schema') as err:
+    with raises(InvalidSchemaError, match='Error validating data dtc_name with schema'):
         dtc_dict = load_example('invalid_wrong_version.yml')
         validate(dtc_dict, 'dtc_name')
 
@@ -63,40 +63,44 @@ def test_valid_basic_window_dtc():
 
 
 def test_invalid_wrong_version():
-    with raises(InvalidSchemaError) as err:
+    with raises(InvalidSchemaError, match='Version: \'2088-03-01\' not in \(\'2018-03-01\',\)'):
         dtc_dict = load_example('invalid_wrong_version.yml')
         validate(dtc_dict)
-    assert "Version: '2088-03-01' not in ('2018-03-01',)" in str(err.value)
 
 
 def test_invalid_missing_time():
-    with raises(InvalidSchemaError, match='Time: Required field missing') as err:
+    with raises(InvalidSchemaError, match='Time: Required field missing'):
         dtc_dict = load_example('invalid_missing_time.yml')
         validate(dtc_dict)
 
 
 def test_invalid_string_instead_of_integer():
-    with raises(InvalidSchemaError, match="Anchor.Max: 'one' is not a int.") as err:
+    with raises(InvalidSchemaError, match="Anchor.Max: 'one' is not a int."):
         dtc_dict = load_example('invalid_string_instead_integer.yml')
         validate(dtc_dict)
 
 
 def test_invalid_non_existing_data_type():
-    with raises(InvalidSchemaError, match="Type: 'foo' is not a DTC Valid Data Type.") as err:
+    with raises(InvalidSchemaError, match="Type: 'foo' is not a DTC Valid Data Type."):
         dtc_dict = load_example('invalid_non_existing_data_type.yml')
         validate(dtc_dict)
 
 
 def test_invalid_incorrect_expression():
     with raises(
-            InvalidSchemaError,
-            match="When: 'x == senor roy' is an invalid python expression.") as err:
+            InvalidSchemaError, match="When: 'x == senor roy' is an invalid python expression."):
         dtc_dict = load_example('invalid_incorrect_expression.yml')
         validate(dtc_dict)
 
 
+def test_invalid_set_expression():
+    with raises(InvalidSchemaError, match='When: \'x = \'test\'\' is an invalid python expression'):
+        dtc_dict = load_example('invalid_set_expression.yml')
+        validate(dtc_dict)
+
+
 def test_invalid_datagroup_has_no_fields():
-    with raises(InvalidSchemaError, match='DataGroups.0.Fields: Required field missing') as err:
+    with raises(InvalidSchemaError, match='DataGroups.0.Fields: Required field missing'):
         dtc_dict = load_example('invalid_datagroup_has_no_fields.yml')
         validate(dtc_dict)
 
@@ -104,6 +108,6 @@ def test_invalid_datagroup_has_no_fields():
 def test_reserved_keywords_as_field_names_raises_invalid_schema_error():
     with raises(
             InvalidSchemaError,
-            match="Name: '_name' starts with _ or containing whitespace characters.") as err:
+            match="Name: '_name' starts with _ or containing whitespace characters."):
         dtc_dict = load_example('invalid_field_name.yml')
         validate(dtc_dict)

--- a/tests/core/syntax/schema_validator_test.py
+++ b/tests/core/syntax/schema_validator_test.py
@@ -1,5 +1,5 @@
 import yaml
-from pytest import raises
+from pytest import raises, mark
 
 from blurr.core.errors import InvalidSchemaError
 from blurr.core.syntax.schema_validator import validate, Identifier, Expression
@@ -62,52 +62,16 @@ def test_valid_basic_window_dtc():
     validate(dtc_dict)
 
 
-def test_invalid_wrong_version():
-    with raises(InvalidSchemaError, match='Version: \'2088-03-01\' not in \(\'2018-03-01\',\)'):
-        dtc_dict = load_example('invalid_wrong_version.yml')
-        validate(dtc_dict)
-
-
-def test_invalid_missing_time():
-    with raises(InvalidSchemaError, match='Time: Required field missing'):
-        dtc_dict = load_example('invalid_missing_time.yml')
-        validate(dtc_dict)
-
-
-def test_invalid_string_instead_of_integer():
-    with raises(InvalidSchemaError, match="Anchor.Max: 'one' is not a int."):
-        dtc_dict = load_example('invalid_string_instead_integer.yml')
-        validate(dtc_dict)
-
-
-def test_invalid_non_existing_data_type():
-    with raises(InvalidSchemaError, match="Type: 'foo' is not a DTC Valid Data Type."):
-        dtc_dict = load_example('invalid_non_existing_data_type.yml')
-        validate(dtc_dict)
-
-
-def test_invalid_incorrect_expression():
-    with raises(
-            InvalidSchemaError, match="When: 'x == senor roy' is an invalid python expression."):
-        dtc_dict = load_example('invalid_incorrect_expression.yml')
-        validate(dtc_dict)
-
-
-def test_invalid_set_expression():
-    with raises(InvalidSchemaError, match='When: \'x = \'test\'\' is an invalid python expression'):
-        dtc_dict = load_example('invalid_set_expression.yml')
-        validate(dtc_dict)
-
-
-def test_invalid_datagroup_has_no_fields():
-    with raises(InvalidSchemaError, match='DataGroups.0.Fields: Required field missing'):
-        dtc_dict = load_example('invalid_datagroup_has_no_fields.yml')
-        validate(dtc_dict)
-
-
-def test_reserved_keywords_as_field_names_raises_invalid_schema_error():
-    with raises(
-            InvalidSchemaError,
-            match="Name: '_name' starts with _ or containing whitespace characters."):
-        dtc_dict = load_example('invalid_field_name.yml')
-        validate(dtc_dict)
+@mark.parametrize("test_file,err_string", [
+    ('invalid_wrong_version.yml', 'Version: \'2088-03-01\' not in \(\'2018-03-01\',\)'),
+    ('invalid_missing_time.yml', 'Time: Required field missing'),
+    ('invalid_string_instead_integer.yml', "Anchor.Max: 'one' is not a int."),
+    ('invalid_non_existing_data_type.yml', "Type: 'foo' is not a DTC Valid Data Type."),
+    ('invalid_incorrect_expression.yml', "When: 'x == senor roy' is an invalid python expression."),
+    ('invalid_set_expression.yml', 'When: \'x = \'test\'\' is an invalid python expression'),
+    ('invalid_datagroup_has_no_fields.yml', 'DataGroups.0.Fields: Required field missing'),
+    ('invalid_field_name.yml', "Name: '_name' starts with _ or containing whitespace characters."),
+])
+def test_invalid_schema(test_file: str, err_string: str) -> None:
+    with raises(InvalidSchemaError, match=err_string):
+        validate(load_example(test_file))


### PR DESCRIPTION
Compile can handle the cases where = is fine and where it would cause an error.

Fixes #167 