### PR TITLE
Update tests to handle the case where IdentityAggregate is used in Anchor:Condition

### DIFF
--- a/tests/core/aggregate_block_test.py
+++ b/tests/core/aggregate_block_test.py
@@ -60,8 +60,7 @@ def create_block_aggregate(schema, time, identity) -> BlockAggregate:
     return block_aggregate
 
 
-def test_block_aggregate_schema_evaluate_without_split(block_aggregate_schema_spec,
-                                                        schema_loader):
+def test_block_aggregate_schema_evaluate_without_split(block_aggregate_schema_spec, schema_loader):
     name = schema_loader.add_schema(block_aggregate_schema_spec)
     block_aggregate_schema = BlockAggregateSchema(name, schema_loader)
 

--- a/tests/core/aggregate_window_test.py
+++ b/tests/core/aggregate_window_test.py
@@ -11,7 +11,7 @@ from blurr.core.aggregate_window import WindowAggregateSchema, WindowAggregate
 
 @fixture
 def window_aggregate_schema(schema_loader_with_mem_store: SchemaLoader, mem_store_name: str,
-                             stream_dtc_name: str) -> WindowAggregateSchema:
+                            stream_dtc_name: str) -> WindowAggregateSchema:
     schema_loader_with_mem_store.add_schema({
         'Type': 'Blurr:Aggregate:BlockAggregate',
         'Name': 'session',

--- a/tests/core/field_complex_test.py
+++ b/tests/core/field_complex_test.py
@@ -105,7 +105,7 @@ def schema_loader() -> SchemaLoader:
 
 @fixture(scope='module')
 def aggregate_schema(schema_loader: SchemaLoader,
-                      aggregate_schema_spec: Dict[str, Any]) -> AggregateSchema:
+                     aggregate_schema_spec: Dict[str, Any]) -> AggregateSchema:
     return VariableAggregateSchema(schema_loader.add_schema(aggregate_schema_spec), schema_loader)
 
 

--- a/tests/core/window_transformer_test.py
+++ b/tests/core/window_transformer_test.py
@@ -10,6 +10,7 @@ from blurr.core.evaluation import Context, EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
 from blurr.core.aggregate_block import BlockAggregate, \
     BlockAggregateSchema
+from blurr.core.store_key import Key
 from blurr.core.transformer_streaming import StreamingTransformer
 from blurr.core.transformer_window import WindowTransformer, \
     WindowTransformerSchema
@@ -34,8 +35,10 @@ def schema_loader():
 @fixture
 def stream_transformer(schema_loader, stream_schema_spec):
     stream_dtc_name = schema_loader.add_schema(stream_schema_spec)
-    return StreamingTransformer(
+    stream_transformer = StreamingTransformer(
         schema_loader.get_schema_object(stream_dtc_name), 'user1', Context())
+    stream_transformer.restore({Key('user1', 'state'): {'country': 'US'}})
+    return stream_transformer
 
 
 @fixture

--- a/tests/data/raw.json
+++ b/tests/data/raw.json
@@ -2,4 +2,5 @@
 {"user_id": "userA", "event_time": "2018-03-07T23:35:31+00:00", "country": "IN"}
 {"user_id": "userA", "event_time": "2018-03-07T23:35:32+00:00"}
 {"user_id": "userB", "event_time": "2018-03-07T22:35:31+00:00"}
+{"user_id": "userB", "event_time": "2018-03-07T23:35:31+00:00"}
 {"user_id": "userC", "event_time": "2018-03-07T22:35:31+00:00"}

--- a/tests/data/window.yml
+++ b/tests/data/window.yml
@@ -7,7 +7,7 @@ Name: ProductMLExample
 SourceDTC: Sessions
 
 Anchor:
-  Condition: Sessions.session.events > 0
+  Condition: Sessions.session.events > 0 and Sessions.state.country != ''
   Max: 1
 
 

--- a/tests/runner/local_runner_test.py
+++ b/tests/runner/local_runner_test.py
@@ -10,7 +10,7 @@ def test_local_runner_stream_only():
     local_runner = LocalRunner(['tests/data/raw.json'], 'tests/data/stream.yml', None)
     local_runner.execute()
 
-    assert len(local_runner._block_data) == 7
+    assert len(local_runner._block_data) == 8
 
     # Stream DTC output
     assert local_runner._block_data[Key('userA', 'session')] == {
@@ -40,8 +40,8 @@ def test_local_runner_stream_only():
 
     assert local_runner._block_data[Key('userB', 'session')] == {
         '_identity': 'userB',
-        '_start_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()),
-        '_end_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()),
+        '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
+        '_end_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
         'events': 1,
         'country': '',
         'continent': ''
@@ -64,7 +64,7 @@ def test_local_runner_with_window():
                                'tests/data/window.yml')
     local_runner.execute()
 
-    assert len(local_runner._block_data) == 7
+    assert len(local_runner._block_data) == 8
 
     # Window DTC output
     assert local_runner._window_data['userA'] == [{


### PR DESCRIPTION
We had already added support to use IdentityAggregate as an Anchor:Condition. This updates tests to test for that.