### PR TITLE
Add support for encode and decode a field when a snapshot or restore is being done.

### DIFF
--- a/blurr/core/aggregate.py
+++ b/blurr/core/aggregate.py
@@ -116,4 +116,4 @@ class Aggregate(BaseItemCollection, ABC):
             raise MissingAttributeError('{item} not defined in {name}'.format(
                 item=item, name=self._name))
 
-        return self._nested_items[item]._snapshot
+        return self._nested_items[item].value

--- a/blurr/core/field.py
+++ b/blurr/core/field.py
@@ -59,7 +59,7 @@ class FieldSchema(BaseSchema, ABC):
         return value
 
 
-class Field(BaseItem, ABC):
+class Field(BaseItem):
     """
     An individual field object responsible for retaining the field value
     """

--- a/blurr/core/field.py
+++ b/blurr/core/field.py
@@ -50,6 +50,14 @@ class FieldSchema(BaseSchema, ABC):
         """
         raise NotImplementedError('type_object is required')
 
+    @staticmethod
+    def encoder(value: Any) -> Any:
+        return value
+
+    @staticmethod
+    def decoder(value: Any) -> Any:
+        return value
+
 
 class Field(BaseItem, ABC):
     """
@@ -96,13 +104,13 @@ class Field(BaseItem, ABC):
         """
         Snapshots the current value of the field
         """
-        return self.value
+        return self._schema.encoder(self.value)
 
     def restore(self, snapshot) -> None:
         """
         Restores the value of a field from a snapshot
         """
-        self.value = snapshot
+        self.value = self._schema.decoder(snapshot)
 
     def reset(self) -> None:
         self.value = self._schema.default

--- a/blurr/core/field_complex.py
+++ b/blurr/core/field_complex.py
@@ -1,3 +1,4 @@
+import typing
 from typing import Any
 
 from blurr.core.field import FieldSchema, ComplexTypeBase
@@ -74,3 +75,11 @@ class SetFieldSchema(FieldSchema):
     @property
     def default(self) -> Any:
         return Set()
+
+    @staticmethod
+    def encoder(value: Any) -> Set:
+        return list(value)
+
+    @staticmethod
+    def decoder(value: Any) -> Set:
+        return Set(value)

--- a/blurr/core/field_simple.py
+++ b/blurr/core/field_simple.py
@@ -52,10 +52,3 @@ class DateTimeFieldSchema(FieldSchema):
     @property
     def default(self) -> Any:
         return None
-
-
-class SimpleField(Field):
-    """
-    Represents a simple field that can be of any native feild type
-    """
-    pass

--- a/blurr/core/loader.py
+++ b/blurr/core/loader.py
@@ -15,14 +15,14 @@ ITEM_MAP = {
     'day': 'blurr.core.window.Window',
     'hour': 'blurr.core.window.Window',
     'count': 'blurr.core.window.Window',
-    'string': 'blurr.core.field_simple.SimpleField',
-    'integer': 'blurr.core.field_simple.SimpleField',
-    'boolean': 'blurr.core.field_simple.SimpleField',
-    'datetime': 'blurr.core.field_simple.SimpleField',
-    'float': 'blurr.core.field_simple.SimpleField',
-    'map': 'blurr.core.field_simple.SimpleField',
-    'list': 'blurr.core.field_simple.SimpleField',
-    'set': 'blurr.core.field_simple.SimpleField',
+    'string': 'blurr.core.field.Field',
+    'integer': 'blurr.core.field.Field',
+    'boolean': 'blurr.core.field.Field',
+    'datetime': 'blurr.core.field.Field',
+    'float': 'blurr.core.field.Field',
+    'map': 'blurr.core.field.Field',
+    'list': 'blurr.core.field.Field',
+    'set': 'blurr.core.field.Field',
 }
 ITEM_MAP_LOWER_CASE = {k.lower(): v for k, v in ITEM_MAP.items()}
 

--- a/blurr/runner/spark_runner.py
+++ b/blurr/runner/spark_runner.py
@@ -53,7 +53,7 @@ class SparkRunner(Runner):
 
     def write_output_file(self,
                           path: str,
-                          per_identity_data: RDD,
+                          per_identity_data: 'RDD',
                           spark_session: Optional['SparkSession'] = None) -> None:
         _spark_session_ = get_spark_session(spark_session)
         if not self._window_dtc:

--- a/tests/core/field_test.py
+++ b/tests/core/field_test.py
@@ -1,14 +1,13 @@
 import logging
-from typing import Dict, Any
+from typing import Any
 
-import pytest
 from pytest import fixture
 
 from blurr.core.evaluation import EvaluationContext
-from blurr.core.field import FieldSchema, Field
+from blurr.core.field import FieldSchema
 from blurr.core.field_complex import SetFieldSchema
-from blurr.core.schema_loader import SchemaLoader
 from blurr.core.field_simple import Field, BooleanFieldSchema, IntegerFieldSchema, FloatFieldSchema
+from blurr.core.schema_loader import SchemaLoader
 
 
 class MockFieldSchema(FieldSchema):

--- a/tests/core/field_test.py
+++ b/tests/core/field_test.py
@@ -6,15 +6,9 @@ from pytest import fixture
 
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.field import FieldSchema, Field
+from blurr.core.field_complex import SetFieldSchema
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.field_simple import SimpleField, BooleanFieldSchema, IntegerFieldSchema, FloatFieldSchema
-
-
-@fixture
-def test_field_schema() -> Dict[str, Any]:
-    schema_loader = SchemaLoader()
-    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': 5})
-    return MockFieldSchema(name, schema_loader)
+from blurr.core.field_simple import Field, BooleanFieldSchema, IntegerFieldSchema, FloatFieldSchema
 
 
 class MockFieldSchema(FieldSchema):
@@ -25,6 +19,13 @@ class MockFieldSchema(FieldSchema):
     @property
     def default(self) -> Any:
         return int(0)
+
+
+@fixture
+def test_field_schema() -> MockFieldSchema:
+    schema_loader = SchemaLoader()
+    name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': 5})
+    return MockFieldSchema(name, schema_loader)
 
 
 class MockField(Field):
@@ -63,7 +64,7 @@ def test_field_evaluate_incorrect_typecast_to_type_default(caplog):
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': '"Hi"'})
     field_schema = IntegerFieldSchema(name, schema_loader)
-    field = SimpleField(field_schema, EvaluationContext())
+    field = Field(field_schema, EvaluationContext())
     field.evaluate()
 
     assert field.value == 0
@@ -76,7 +77,7 @@ def test_field_evaluate_implicit_typecast_integer():
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'integer', 'Value': '23.45'})
     field_schema = IntegerFieldSchema(name, schema_loader)
-    field = SimpleField(field_schema, EvaluationContext())
+    field = Field(field_schema, EvaluationContext())
     field.evaluate()
 
     assert field._snapshot == 23
@@ -86,7 +87,7 @@ def test_field_evaluate_implicit_typecast_float():
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'float', 'Value': '23'})
     field_schema = FloatFieldSchema(name, schema_loader)
-    field = SimpleField(field_schema, EvaluationContext())
+    field = Field(field_schema, EvaluationContext())
     field.evaluate()
 
     assert field._snapshot == 23.0
@@ -96,7 +97,7 @@ def test_field_evaluate_implicit_typecast_bool():
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema({'Name': 'max_attempts', 'Type': 'boolean', 'Value': '1+2'})
     field_schema = BooleanFieldSchema(name, schema_loader)
-    field = SimpleField(field_schema, EvaluationContext())
+    field = Field(field_schema, EvaluationContext())
     field.evaluate()
 
     assert field._snapshot is True
@@ -122,3 +123,30 @@ def test_field_reset(test_field_schema):
     assert field.value == 5
     field.reset()
     assert field.value == 0
+
+
+def test_set_field_snapshot_encoding():
+    schema_loader = SchemaLoader()
+    name = schema_loader.add_schema({'Name': 'test', 'Type': 'set', 'Value': 'test.add(0).add(1)'})
+    field_schema = SetFieldSchema(name, schema_loader)
+    field = Field(field_schema, EvaluationContext())
+    field._evaluation_context.global_add('test', field.value)
+    field.evaluate()
+
+    assert field.value == {0, 1}
+    assert field._snapshot
+    assert isinstance(field._snapshot, list)
+    assert set(field._snapshot) == field.value
+
+
+def test_set_field_snapshot_decoding():
+    schema_loader = SchemaLoader()
+    name = schema_loader.add_schema({'Name': 'test', 'Type': 'set', 'Value': 'test.add(0).add(1)'})
+    field_schema = SetFieldSchema(name, schema_loader)
+    field = Field(field_schema, EvaluationContext())
+    field.restore([2, 3])
+
+    assert field.value == {2, 3}
+    assert field._snapshot
+    assert isinstance(field._snapshot, list)
+    assert set(field._snapshot) == field.value

--- a/tests/core/window_transformer_test.py
+++ b/tests/core/window_transformer_test.py
@@ -33,7 +33,8 @@ def schema_loader():
 @fixture
 def stream_transformer(schema_loader, stream_schema_spec):
     stream_dtc_name = schema_loader.add_schema(stream_schema_spec)
-    stream_transformer = StreamingTransformer(schema_loader.get_schema_object(stream_dtc_name), 'user1')
+    stream_transformer = StreamingTransformer(
+        schema_loader.get_schema_object(stream_dtc_name), 'user1')
     stream_transformer.restore({Key('user1', 'state'): {'country': 'US'}})
     return stream_transformer
 

--- a/tests/extended/extended_test.py
+++ b/tests/extended/extended_test.py
@@ -22,9 +22,15 @@ def test_extended_runner():
         'offers_purchased': {
             'offer1': 1
         },
-        'badges': {'bronze', 'silver', 'gold'},
+        'badges': {'silver', 'bronze', 'gold'},
         'signin_method': 'other'
     }
+    # Assert the badges is a list and then convert to set for unordered comparison.
+    # badges in DTC is a set but we encode it into a list when creating a snapshot. The creation of
+    # the list cant result in a non-deterministic element order in the list.
+    assert result_state['badges']
+    assert isinstance(result_state['badges'], list)
+    result_state['badges'] = set(result_state['badges'])
 
     assert result_state == expected_state
 


### PR DESCRIPTION
**PR Checklist**

_Please make sure to review and check all of these items:_

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated

**What kind of change does this PR introduce?**
Adding support to encode a field when a snapshot is being generated and decode a field when the snapshot is being restored. This was needed as 'Set' is something that serializers like JSON do not support.

Also removed SimpleField as it was redundant and replaced it directly by Field.