### PR TITLE
Renamed BlockAggregate to StreamingAggregate and made it into an ABC.

### DIFF
--- a/blurr/core/aggregate.py
+++ b/blurr/core/aggregate.py
@@ -5,8 +5,10 @@ from abc import ABC
 from blurr.core.base import BaseSchemaCollection, BaseItemCollection, BaseItem
 from blurr.core.errors import MissingAttributeError
 from blurr.core.evaluation import EvaluationContext
+from blurr.core.field import Field
 from blurr.core.loader import TypeLoader
 from blurr.core.schema_loader import SchemaLoader
+from blurr.core.store import Store
 from blurr.core.store_key import Key
 
 
@@ -72,13 +74,13 @@ class Aggregate(BaseItemCollection, ABC):
         super().__init__(schema, evaluation_context)
         self._identity = identity
 
-        self._fields: Dict[str, Type[BaseItem]] = {
+        self._fields: Dict[str, Field] = {
             name: TypeLoader.load_item(item_schema.type)(item_schema, self._evaluation_context)
             for name, item_schema in self._schema.nested_schema.items()
         }
 
     @property
-    def _nested_items(self) -> Dict[str, Type[BaseItem]]:
+    def _nested_items(self) -> Dict[str, Field]:
         """
         Returns the dictionary of fields the Aggregate contains
         """

--- a/blurr/core/aggregate_activity.py
+++ b/blurr/core/aggregate_activity.py
@@ -1,11 +1,10 @@
 from datetime import timedelta
 
-from blurr.core.aggregate_block import BlockAggregate, BlockAggregateSchema
-from blurr.core.evaluation import EvaluationContext
+from blurr.core.aggregate_streaming import StreamingAggregate, StreamingAggregateSchema
 from blurr.core.schema_loader import SchemaLoader
 
 
-class ActivityAggregateSchema(BlockAggregateSchema):
+class ActivityAggregateSchema(StreamingAggregateSchema):
     ATTRIBUTE_SEPARATE_BY_INACTIVE_SECONDS = 'SeparateByInactiveSeconds'
 
     def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
@@ -15,16 +14,19 @@ class ActivityAggregateSchema(BlockAggregateSchema):
             seconds=int(self._spec[self.ATTRIBUTE_SEPARATE_BY_INACTIVE_SECONDS]))
 
 
-class ActivityAggregate(BlockAggregate):
+class ActivityAggregate(StreamingAggregate):
     """ Aggregates activity in blocks separated by periods of inactivity"""
 
     def evaluate(self) -> None:
         time = self._evaluation_context.global_context['time']
 
         # If the event time is beyond separation threshold, create a new block
-        if self._start_time and (time < self._start_time - self._schema.separation_interval or
-                                 time > self._end_time + self._schema.separation_interval):
+        if self._start_time and (time < self._start_time - self._schema.separation_interval
+                                 or time > self._end_time + self._schema.separation_interval):
             self.persist(self._start_time)
             self.reset()
 
         super().evaluate()
+
+    def persist(self, timestamp=None) -> None:
+        super().persist(timestamp if timestamp else self._start_time)

--- a/blurr/core/aggregate_identity.py
+++ b/blurr/core/aggregate_identity.py
@@ -1,9 +1,9 @@
-from blurr.core.aggregate import Aggregate, AggregateSchema
+from blurr.core.aggregate_streaming import StreamingAggregateSchema, StreamingAggregate
 
 
-class IdentityAggregateSchema(AggregateSchema):
+class IdentityAggregateSchema(StreamingAggregateSchema):
     pass
 
 
-class IdentityAggregate(Aggregate):
+class IdentityAggregate(StreamingAggregate):
     pass

--- a/blurr/core/aggregate_label.py
+++ b/blurr/core/aggregate_label.py
@@ -1,12 +1,12 @@
 from typing import Dict, Any
 
-from blurr.core.aggregate_block import BlockAggregate, BlockAggregateSchema
+from blurr.core.aggregate_streaming import StreamingAggregate, StreamingAggregateSchema
 from blurr.core.evaluation import Expression, EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
 from blurr.core.store_key import Key
 
 
-class LabelAggregateSchema(BlockAggregateSchema):
+class LabelAggregateSchema(StreamingAggregateSchema):
     """ Schema for Block Aggregation by a Label that can determined by the record being processed """
 
     ATTRIBUTE_LABEL = 'Label'
@@ -29,7 +29,7 @@ class LabelAggregateSchema(BlockAggregateSchema):
         return super().extend_schema(spec)
 
 
-class LabelAggregate(BlockAggregate):
+class LabelAggregate(StreamingAggregate):
     """ Aggregates records in blocks by a label calculated from the record """
 
     def __init__(self, schema: LabelAggregateSchema, identity: str,

--- a/blurr/core/aggregate_window.py
+++ b/blurr/core/aggregate_window.py
@@ -2,12 +2,11 @@ from datetime import datetime, timedelta
 from typing import Any, List, Tuple
 
 from blurr.core.aggregate import Aggregate, AggregateSchema
+from blurr.core.aggregate_streaming import StreamingAggregate
 from blurr.core.errors import PrepareWindowMissingBlocksError
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.aggregate_block import BlockAggregate
 from blurr.core.store_key import Key
-from blurr.core.base import BaseItem
 
 
 class WindowAggregateSchema(AggregateSchema):
@@ -28,8 +27,8 @@ class _WindowSource:
     Represents a window on the pre-aggregated source data.
     """
 
-    def __init__(self, block_list: List[BlockAggregate]):
-        self.view: List[BlockAggregate] = block_list
+    def __init__(self, block_list: List[StreamingAggregate]):
+        self.view: List[StreamingAggregate] = block_list
 
     def __getattr__(self, item: str) -> List[Any]:
         return [getattr(block, item) for block in self.view]
@@ -94,15 +93,15 @@ class WindowAggregate(Aggregate):
         elif self._schema.window_type == 'hour':
             return start_time + timedelta(hours=self._schema.window_value)
 
-    def _load_blocks(self, blocks: List[Tuple[Key, Any]]) -> List[BlockAggregate]:
+    def _load_blocks(self, blocks: List[Tuple[Key, Any]]) -> List[StreamingAggregate]:
         """
         Converts [(Key, block)] to [BlockAggregate]
         :param blocks: List of (Key, block) blocks.
         :return: List of BlockAggregate
         """
         return [
-            BlockAggregate(self._schema.source, self._identity, EvaluationContext()).restore(block)
-            for (_, block) in blocks
+            StreamingAggregate(self._schema.source, self._identity,
+                               EvaluationContext()).restore(block) for (_, block) in blocks
         ]
 
     def evaluate(self) -> None:

--- a/blurr/core/anchor.py
+++ b/blurr/core/anchor.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from blurr.core.base import BaseSchema, BaseItem
 from blurr.core.evaluation import Expression, EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.aggregate_block import BlockAggregate
+from blurr.core.aggregate_streaming import StreamingAggregate
 
 
 class AnchorSchema(BaseSchema):
@@ -29,7 +29,7 @@ class Anchor(BaseItem):
         self.condition_met: Dict[datetime, int] = defaultdict(int)
         self.anchor_block = None
 
-    def evaluate_anchor(self, block: BlockAggregate) -> bool:
+    def evaluate_anchor(self, block: StreamingAggregate) -> bool:
         self.anchor_block = block
         if self.max_condition_met(block):
             return False
@@ -45,7 +45,7 @@ class Anchor(BaseItem):
     def evaluate(self) -> bool:
         return self._schema.condition.evaluate(self._evaluation_context)
 
-    def max_condition_met(self, block: BlockAggregate) -> bool:
+    def max_condition_met(self, block: StreamingAggregate) -> bool:
         if self._schema.max is None:
             return False
         return self.condition_met[block._start_time.date()] >= self._schema.max

--- a/blurr/core/loader.py
+++ b/blurr/core/loader.py
@@ -7,7 +7,6 @@ from blurr.core.errors import InvalidSchemaError
 ITEM_MAP = {
     'Blurr:Transform:Streaming': 'blurr.core.transformer_streaming.StreamingTransformer',
     'Blurr:Transform:Window': 'blurr.core.transformer_window.WindowTransformer',
-    'Blurr:Aggregate:BlockAggregate': 'blurr.core.aggregate_block.BlockAggregate',
     'Blurr:Aggregate:LabelAggregate': 'blurr.core.aggregate_label.LabelAggregate',
     'Blurr:Aggregate:ActivityAggregate': 'blurr.core.aggregate_activity.ActivityAggregate',
     'Blurr:Aggregate:IdentityAggregate': 'blurr.core.aggregate_identity.IdentityAggregate',
@@ -30,7 +29,6 @@ ITEM_MAP_LOWER_CASE = {k.lower(): v for k, v in ITEM_MAP.items()}
 SCHEMA_MAP = {
     'Blurr:Transform:Streaming': 'blurr.core.transformer_streaming.StreamingTransformerSchema',
     'Blurr:Transform:Window': 'blurr.core.transformer_window.WindowTransformerSchema',
-    'Blurr:Aggregate:BlockAggregate': 'blurr.core.aggregate_block.BlockAggregateSchema',
     'Blurr:Aggregate:LabelAggregate': 'blurr.core.aggregate_label.LabelAggregateSchema',
     'Blurr:Aggregate:ActivityAggregate': 'blurr.core.aggregate_activity.ActivityAggregateSchema',
     'Blurr:Aggregate:IdentityAggregate': 'blurr.core.aggregate_identity.IdentityAggregateSchema',

--- a/blurr/core/transformer_window.py
+++ b/blurr/core/transformer_window.py
@@ -6,7 +6,7 @@ from blurr.core.errors import AnchorBlockNotDefinedError, \
     PrepareWindowMissingBlocksError
 from blurr.core.evaluation import Context, EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.aggregate_block import BlockAggregate
+from blurr.core.aggregate_streaming import StreamingAggregate
 from blurr.core.transformer import Transformer, TransformerSchema
 
 
@@ -44,7 +44,7 @@ class WindowTransformer(Transformer):
         self._evaluation_context.merge(EvaluationContext(context))
         self._anchor = Anchor(schema.anchor, self._evaluation_context)
 
-    def evaluate(self, block: BlockAggregate) -> bool:
+    def evaluate(self, block: StreamingAggregate) -> bool:
         """
         Evaluates the anchor condition against the specified block.
         :param block: Block to run the anchor condition against.

--- a/blurr/runner/identity_runner.py
+++ b/blurr/runner/identity_runner.py
@@ -2,7 +2,9 @@ from datetime import datetime
 from typing import List, Dict, Tuple, Any, Optional
 
 from blurr.core import logging
-from blurr.core.aggregate_block import BlockAggregate
+from blurr.core.aggregate_activity import ActivityAggregate
+from blurr.core.aggregate_identity import IdentityAggregate
+from blurr.core.aggregate_label import LabelAggregate
 from blurr.core.errors import PrepareWindowMissingBlocksError
 from blurr.core.evaluation import Context
 from blurr.core.record import Record
@@ -58,10 +60,10 @@ def execute_window_dtc(identity: str, schema_loader: SchemaLoader,
 
     block_obj = None
     for aggregate in stream_transformer._nested_items.values():
-        if not isinstance(aggregate, BlockAggregate):
+        if not isinstance(aggregate, (LabelAggregate, ActivityAggregate)):
             continue
         if block_obj is not None:
-            raise Exception(('Window operation is supported against Streaming ',
+            raise Exception(('Window operation is supported against Streaming '
                              'DTC with only one BlockAggregate'))
         block_obj = aggregate
 

--- a/tests/cli/transform_test.py
+++ b/tests/cli/transform_test.py
@@ -68,9 +68,11 @@ def test_transform_only_stream(capsys, runner) -> None:
         'continent': 'North America'
     }), out)
     assert_record_in_ouput(('userA/state', {
-        '_identity': 'userA',
-        'country': 'IN',
-        'continent': 'World'
+        "_identity": "userA",
+        "_start_time": "2018-03-07 22:35:31+00:00",
+        "_end_time": "2018-03-07 23:35:32+00:00",
+        "country": "IN",
+        "continent": "World"
     }), out)
     assert_record_in_ouput(('userA/session/2018-03-07T23:35:31+00:00', {
         '_identity': 'userA',

--- a/tests/core/aggregate_activity_test.py
+++ b/tests/core/aggregate_activity_test.py
@@ -47,11 +47,31 @@ def activity_aggregate_schema(activity_aggregate_schema_spec: Dict[str, Any],
 @fixture
 def activity_events() -> List[Record]:
     return [
-        Record({'id': 'user1', 'event_value': 10, 'event_time': '2018-01-01T01:01:01+00:00'}),
-        Record({'id': 'user1', 'event_value': 100, 'event_time': '2018-01-01T01:01:05+00:00'}),
-        Record({'id': 'user1', 'event_value': 1, 'event_time': '2018-01-01T01:02:01+00:00'}),
-        Record({'id': 'user1', 'event_value': 1000, 'event_time': '2018-01-01T03:01:01+00:00'}),
-        Record({'id': 'user1', 'event_value': 10000, 'event_time': '2018-01-02T01:01:01+00:00'})
+        Record({
+            'id': 'user1',
+            'event_value': 10,
+            'event_time': '2018-01-01T01:01:01+00:00'
+        }),
+        Record({
+            'id': 'user1',
+            'event_value': 100,
+            'event_time': '2018-01-01T01:01:05+00:00'
+        }),
+        Record({
+            'id': 'user1',
+            'event_value': 1,
+            'event_time': '2018-01-01T01:02:01+00:00'
+        }),
+        Record({
+            'id': 'user1',
+            'event_value': 1000,
+            'event_time': '2018-01-01T03:01:01+00:00'
+        }),
+        Record({
+            'id': 'user1',
+            'event_value': 10000,
+            'event_time': '2018-01-02T01:01:01+00:00'
+        })
     ]
 
 
@@ -62,7 +82,7 @@ def evaluate_event(record: Record, aggregate: ActivityAggregate) -> None:
 
 
 def test_aggregate_final_state(activity_aggregate_schema: ActivityAggregateSchema,
-                             activity_events: List[Record]) -> None:
+                               activity_events: List[Record]) -> None:
     # Initialize the starting state
     identity = 'user1'
     evaluation_context = EvaluationContext()
@@ -77,17 +97,32 @@ def test_aggregate_final_state(activity_aggregate_schema: ActivityAggregateSchem
 
     store_state = activity_aggregate._schema.store.get_all()
     assert len(store_state) == 3
-    assert store_state.get(Key('user1', 'activity_aggr', datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc))) == {
-        '_identity': 'user1', '_start_time': datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc),
-        '_end_time': datetime(2018, 1, 1, 1, 2, 1, 0, timezone.utc), 'sum': 111, 'count': 3}
+    assert store_state.get(
+        Key('user1', 'activity_aggr', datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc))) == {
+            '_identity': 'user1',
+            '_start_time': datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc),
+            '_end_time': datetime(2018, 1, 1, 1, 2, 1, 0, timezone.utc),
+            'sum': 111,
+            'count': 3
+        }
 
-    assert store_state.get(Key('user1', 'activity_aggr', datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc))) == {
-        '_identity': 'user1', '_start_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc),
-        '_end_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc), 'sum': 1000, 'count': 1}
+    assert store_state.get(
+        Key('user1', 'activity_aggr', datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc))) == {
+            '_identity': 'user1',
+            '_start_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc),
+            '_end_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc),
+            'sum': 1000,
+            'count': 1
+        }
 
-    assert store_state.get(Key('user1', 'activity_aggr', datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc))) == {
-        '_identity': 'user1', '_start_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc),
-        '_end_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc), 'sum': 10000, 'count': 1}
+    assert store_state.get(
+        Key('user1', 'activity_aggr', datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc))) == {
+            '_identity': 'user1',
+            '_start_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc),
+            '_end_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc),
+            'sum': 10000,
+            'count': 1
+        }
 
 
 def test_evaluate_no_separation(activity_aggregate_schema: ActivityAggregateSchema,

--- a/tests/core/aggregate_block_schema_test.py
+++ b/tests/core/aggregate_block_schema_test.py
@@ -4,7 +4,7 @@ from pytest import fixture
 
 from blurr.core.evaluation import Expression
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.aggregate_block import BlockAggregateSchema
+from blurr.core.aggregate_streaming import StreamingAggregateSchema
 
 
 @fixture
@@ -47,8 +47,7 @@ def match_fields(fields):
 def test_block_aggregate_schema_initialization(block_aggregate_schema_spec):
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(block_aggregate_schema_spec)
-    block_aggregate_schema = BlockAggregateSchema(name, schema_loader)
-    assert block_aggregate_schema.split is None
+    assert StreamingAggregateSchema(name, schema_loader)
     assert match_fields(block_aggregate_schema_spec['Fields'])
 
     loader_spec = schema_loader.get_schema_spec(name)
@@ -59,8 +58,7 @@ def test_block_aggregate_schema_with_split_initialization(block_aggregate_schema
     block_aggregate_schema_spec['Split'] = '4 > 2'
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema(block_aggregate_schema_spec)
-    block_aggregate_schema = BlockAggregateSchema(name, schema_loader)
-    assert isinstance(block_aggregate_schema.split, Expression)
+    assert StreamingAggregateSchema(name, schema_loader)
     assert match_fields(block_aggregate_schema_spec['Fields'])
 
     loader_spec = schema_loader.get_schema_spec(name)

--- a/tests/core/aggregate_block_test.py
+++ b/tests/core/aggregate_block_test.py
@@ -6,8 +6,8 @@ from pytest import fixture
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.field import Field
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.aggregate_block import BlockAggregateSchema, \
-    BlockAggregate
+from blurr.core.aggregate_streaming import StreamingAggregateSchema, \
+    StreamingAggregate
 from blurr.core.store_key import Key
 
 
@@ -37,22 +37,17 @@ def schema_loader(store_spec) -> SchemaLoader:
     return schema_loader
 
 
-def check_fields(fields: Dict[str, Field], expected_field_values: Dict[str, Any]) -> bool:
-    if len(fields) != len(expected_field_values):
-        return False
+def check_fields(fields: Dict[str, Field], expected_field_values: Dict[str, Any]) -> None:
+    assert len(fields) == len(expected_field_values)
 
     for field_name, field in fields.items():
-        if not isinstance(field, Field):
-            return False
-        if field.value != expected_field_values[field_name]:
-            return False
-
-    return True
+        assert isinstance(field, Field)
+        assert field.value == expected_field_values[field_name]
 
 
-def create_block_aggregate(schema, time, identity) -> BlockAggregate:
+def create_block_aggregate(schema, time, identity) -> StreamingAggregate:
     evaluation_context = EvaluationContext()
-    block_aggregate = BlockAggregate(
+    block_aggregate = StreamingAggregate(
         schema=schema, identity=identity, evaluation_context=evaluation_context)
     evaluation_context.global_add('time', time)
     evaluation_context.global_add('user', block_aggregate)
@@ -62,7 +57,7 @@ def create_block_aggregate(schema, time, identity) -> BlockAggregate:
 
 def test_block_aggregate_schema_evaluate_without_split(block_aggregate_schema_spec, schema_loader):
     name = schema_loader.add_schema(block_aggregate_schema_spec)
-    block_aggregate_schema = BlockAggregateSchema(name, schema_loader)
+    block_aggregate_schema = StreamingAggregateSchema(name, schema_loader)
 
     identity = 'userA'
     time = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
@@ -71,7 +66,7 @@ def test_block_aggregate_schema_evaluate_without_split(block_aggregate_schema_sp
 
     # Check eval results of various fields
     assert len(block_aggregate._nested_items) == 4
-    assert check_fields(block_aggregate._nested_items, {
+    check_fields(block_aggregate._nested_items, {
         '_identity': identity,
         'event_count': 1,
         '_start_time': time,
@@ -83,39 +78,3 @@ def test_block_aggregate_schema_evaluate_without_split(block_aggregate_schema_sp
         Key(identity=block_aggregate._identity,
             group=block_aggregate._name,
             timestamp=block_aggregate._start_time)) is None
-
-
-def test_block_aggregate_schema_evaluate_with_split(block_aggregate_schema_spec, schema_loader):
-    block_aggregate_schema_spec['Split'] = 'user.event_count == 2'
-    name = schema_loader.add_schema(block_aggregate_schema_spec)
-    block_aggregate_schema = BlockAggregateSchema(name, schema_loader)
-
-    identity = 'userA'
-    time = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
-    block_aggregate = create_block_aggregate(block_aggregate_schema, time, identity)
-    block_aggregate.evaluate()
-    block_aggregate.evaluate()
-
-    # Check eval results of various fields before split
-    assert check_fields(block_aggregate._nested_items, {
-        '_identity': identity,
-        'event_count': 2,
-        '_start_time': time,
-        '_end_time': time
-    })
-
-    current_snapshot = block_aggregate._snapshot
-    block_aggregate.evaluate()
-
-    # Check eval results of various fields
-    assert check_fields(block_aggregate._nested_items, {
-        '_identity': identity,
-        'event_count': 1,
-        '_start_time': time,
-        '_end_time': time
-    })
-
-    # Check aggregate snapshot present in store
-    assert block_aggregate_schema.store.get(
-        Key(identity=block_aggregate._identity, group=block_aggregate._name,
-            timestamp=time)) == current_snapshot

--- a/tests/core/aggregate_window_schema_test.py
+++ b/tests/core/aggregate_window_schema_test.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from blurr.core.aggregate_block import BlockAggregateSchema
+from blurr.core.aggregate_streaming import StreamingAggregateSchema
 from blurr.core.errors import InvalidSchemaError
 from blurr.core.schema_loader import SchemaLoader
 from blurr.core.aggregate_window import WindowAggregateSchema
@@ -9,9 +9,10 @@ from blurr.core.aggregate_window import WindowAggregateSchema
 def test_initialization_with_valid_source(schema_loader_with_mem_store: SchemaLoader,
                                           mem_store_name: str, stream_dtc_name: str):
     schema_loader_with_mem_store.add_schema({
-        'Type': 'Blurr:Aggregate:BlockAggregate',
+        'Type': 'Blurr:Aggregate:ActivityAggregate',
         'Name': 'session',
         'Store': mem_store_name,
+        'SeparateByInactiveSeconds': 1800,
         'Fields': [
             {
                 'Name': 'events',
@@ -36,7 +37,7 @@ def test_initialization_with_valid_source(schema_loader_with_mem_store: SchemaLo
     window_aggregate_schema = WindowAggregateSchema(name, schema_loader_with_mem_store)
     assert window_aggregate_schema.window_type == 'day'
     assert window_aggregate_schema.window_value == 1
-    assert isinstance(window_aggregate_schema.source, BlockAggregateSchema)
+    assert isinstance(window_aggregate_schema.source, StreamingAggregateSchema)
     assert window_aggregate_schema.source.name == 'session'
 
 

--- a/tests/core/aggregate_window_test.py
+++ b/tests/core/aggregate_window_test.py
@@ -13,9 +13,10 @@ from blurr.core.aggregate_window import WindowAggregateSchema, WindowAggregate
 def window_aggregate_schema(schema_loader_with_mem_store: SchemaLoader, mem_store_name: str,
                             stream_dtc_name: str) -> WindowAggregateSchema:
     schema_loader_with_mem_store.add_schema({
-        'Type': 'Blurr:Aggregate:BlockAggregate',
+        'Type': 'Blurr:Aggregate:ActivityAggregate',
         'Name': 'session',
         'Store': mem_store_name,
+        'SeparateByInactiveSeconds': 1800,
         'Fields': [
             {
                 'Name': 'events',

--- a/tests/core/anchor_test.py
+++ b/tests/core/anchor_test.py
@@ -5,8 +5,8 @@ from pytest import fixture
 from blurr.core.anchor import AnchorSchema, Anchor
 from blurr.core.evaluation import EvaluationContext, Expression
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.aggregate_block import BlockAggregateSchema, \
-    BlockAggregate
+from blurr.core.aggregate_streaming import StreamingAggregateSchema, \
+    StreamingAggregate
 
 
 @fixture
@@ -37,7 +37,7 @@ def anchor_schema_max_two(schema_loader: SchemaLoader) -> AnchorSchema:
 
 
 @fixture
-def block_schema(schema_loader: SchemaLoader) -> BlockAggregateSchema:
+def block_schema(schema_loader: SchemaLoader) -> StreamingAggregateSchema:
     name = schema_loader.add_schema({
         'Type': 'Blurr:Aggregate:BlockAggregate',
         'Name': 'session',
@@ -49,12 +49,12 @@ def block_schema(schema_loader: SchemaLoader) -> BlockAggregateSchema:
             },
         ],
     })
-    return BlockAggregateSchema(name, schema_loader)
+    return StreamingAggregateSchema(name, schema_loader)
 
 
 @fixture
-def block_item(block_schema: BlockAggregateSchema) -> BlockAggregate:
-    block = BlockAggregate(block_schema, 'user1', EvaluationContext())
+def block_item(block_schema: StreamingAggregateSchema) -> StreamingAggregate:
+    block = StreamingAggregate(block_schema, 'user1', EvaluationContext())
     block.restore({
         'events': 3,
         '_start_time': datetime(2018, 3, 7, 22, 36, 31, 0, timezone.utc),
@@ -63,14 +63,16 @@ def block_item(block_schema: BlockAggregateSchema) -> BlockAggregate:
     return block
 
 
-def test_anchor_max_one(anchor_schema_max_one: AnchorSchema, block_item: BlockAggregate) -> None:
+def test_anchor_max_one(anchor_schema_max_one: AnchorSchema,
+                        block_item: StreamingAggregate) -> None:
     anchor = Anchor(anchor_schema_max_one, EvaluationContext())
     assert anchor.evaluate_anchor(block_item) is True
     anchor.add_condition_met()
     assert anchor.evaluate_anchor(block_item) is False
 
 
-def test_anchor_max_two(anchor_schema_max_two: AnchorSchema, block_item: BlockAggregate) -> None:
+def test_anchor_max_two(anchor_schema_max_two: AnchorSchema,
+                        block_item: StreamingAggregate) -> None:
     anchor = Anchor(anchor_schema_max_two, EvaluationContext())
     assert anchor.evaluate_anchor(block_item) is True
     anchor.add_condition_met()
@@ -80,7 +82,7 @@ def test_anchor_max_two(anchor_schema_max_two: AnchorSchema, block_item: BlockAg
 
 
 def test_anchor_max_not_specified(anchor_schema_max_one: AnchorSchema,
-                                  block_item: BlockAggregate) -> None:
+                                  block_item: StreamingAggregate) -> None:
     anchor_schema_max_one.max = None
     anchor = Anchor(anchor_schema_max_one, EvaluationContext())
     assert anchor.evaluate_anchor(block_item) is True
@@ -90,7 +92,8 @@ def test_anchor_max_not_specified(anchor_schema_max_one: AnchorSchema,
     assert anchor.evaluate_anchor(block_item) is True
 
 
-def test_anchor_condition(anchor_schema_max_one: AnchorSchema, block_item: BlockAggregate) -> None:
+def test_anchor_condition(anchor_schema_max_one: AnchorSchema,
+                          block_item: StreamingAggregate) -> None:
     anchor_schema_max_one.condition = Expression('session.events > 3')
     eval_context = EvaluationContext()
     anchor = Anchor(anchor_schema_max_one, eval_context)

--- a/tests/core/streaming_transformer_test.py
+++ b/tests/core/streaming_transformer_test.py
@@ -130,4 +130,11 @@ def test_streaming_transformer_evaluate(schema_loader: SchemaLoader,
     transformer = StreamingTransformer(transformer_schema, 'user1')
     transformer.evaluate(Record())
 
-    assert transformer._snapshot == {'test_group': {'_identity': 'user1', 'events': 1}}
+    assert transformer._snapshot == {
+        'test_group': {
+            '_identity': 'user1',
+            '_end_time': datetime(2016, 10, 10, 0, 0),
+            '_start_time': datetime(2016, 10, 10, 0, 0),
+            'events': 1
+        }
+    }

--- a/tests/core/transformer_test.py
+++ b/tests/core/transformer_test.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict, Any
 
 import pytest
@@ -79,11 +80,22 @@ def test_transformer_finalize(test_transformer: MockTransformer,
     store = schema_loader.get_schema_object('test.memstore')
 
     test_transformer.finalize()
-    assert store.get(Key('user1', 'test_group')) == {'_identity': '', 'events': 0}
+    assert store.get(Key('user1', 'test_group')) == {
+        '_identity': '',
+        'events': 0,
+        '_end_time': None,
+        '_start_time': None
+    }
 
+    test_transformer._evaluation_context.global_add('time', datetime(2018, 3, 1, 10, 10, 10))
     test_transformer.evaluate()
     test_transformer.finalize()
-    assert store.get(Key('user1', 'test_group')) == {'_identity': 'user1', 'events': 1}
+    assert store.get(Key('user1', 'test_group')) == {
+        '_identity': 'user1',
+        'events': 1,
+        '_end_time': datetime(2018, 3, 1, 10, 10, 10),
+        '_start_time': datetime(2018, 3, 1, 10, 10, 10)
+    }
 
 
 def test_transformer_get_attr(test_transformer: MockTransformer) -> None:

--- a/tests/core/window_transformer_test.py
+++ b/tests/core/window_transformer_test.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from pytest import fixture
 
-from blurr.core.aggregate_block import BlockAggregate
+from blurr.core.aggregate_streaming import StreamingAggregate
 from blurr.core.anchor import AnchorSchema
 from blurr.core.errors import AnchorBlockNotDefinedError, PrepareWindowMissingBlocksError
 from blurr.core.evaluation import Context
@@ -53,7 +53,7 @@ def window_transformer(schema_loader, stream_transformer, window_schema_spec):
 def block_aggregate(stream_transformer):
     block = None
     for aggregate in stream_transformer._nested_items.values():
-        if isinstance(aggregate, BlockAggregate):
+        if isinstance(aggregate, StreamingAggregate):
             block = aggregate
 
     return block

--- a/tests/data/stream.yml
+++ b/tests/data/stream.yml
@@ -26,9 +26,9 @@ Aggregates:
       - { Name: country, Type: string, Value: source.country }
       - { Name: continent, Type: string, Value: vars.continent, When: bool(vars.continent) }
   -
-    Type: 'Blurr:Aggregate:BlockAggregate'
+    Type: 'Blurr:Aggregate:ActivityAggregate'
     Name: session
-    Split: '(time - session._end_time).seconds > 1800'
+    SeparateByInactiveSeconds: 1800
     Store: memory
     Fields:
       - { Name: events, Type: integer, Value: 'session.events + 1' }

--- a/tests/extended/extended_test.py
+++ b/tests/extended/extended_test.py
@@ -13,6 +13,8 @@ def test_extended_runner():
     result_state = local_runner._block_data[Key('user-1', 'state')]
     expected_state = {
         '_identity': 'user-1',
+        '_end_time': datetime(2016, 2, 13, 0, 1, 25),
+        '_start_time': datetime(2016, 2, 10, 0, 0),
         'country': 'US',
         'build': 245,
         'is_paid': True,
@@ -34,7 +36,8 @@ def test_extended_runner():
 
     assert result_state == expected_state
 
-    result_session = local_runner._block_data[Key('user-1', 'session', datetime(2016, 2, 13, 0, 0, 58))]
+    result_session = local_runner._block_data[Key('user-1', 'session',
+                                                  datetime(2016, 2, 13, 0, 0, 58))]
     expected_session = {
         '_identity': 'user-1',
         '_start_time': datetime(2016, 2, 13, 0, 0, 58),

--- a/tests/extended/stream.yml
+++ b/tests/extended/stream.yml
@@ -63,9 +63,11 @@ Aggregates:
         When: state.build > 210 and state.build < 440
 
 
-  - Type: Blurr:Aggregate:BlockAggregate
+  - Type: Blurr:Aggregate:ActivityAggregate
     Name: session
-    Split: (time - session._end_time).total_seconds() > 1800 or session.session_id != source.session_id
+    # Add back session.session_id != source.session_id when we add support for keys to activity
+    # aggregate
+    SeparateByInactiveSeconds: 1800
     Store: memory
     Fields:
       - { Name: session_id, Type: string, Value: source.session_id }

--- a/tests/runner/local_runner_test.py
+++ b/tests/runner/local_runner_test.py
@@ -34,7 +34,9 @@ def test_only_stream_dtc_provided():
     assert local_runner._block_data[Key('userA', 'state')] == {
         '_identity': 'userA',
         'country': 'IN',
-        'continent': 'World'
+        'continent': 'World',
+        '_end_time': datetime(2018, 3, 7, 23, 35, 32, tzinfo=tzutc()),
+        '_start_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc())
     }
 
     assert local_runner._block_data[Key('userB', 'session', datetime(2018, 3, 7, 23, 35, 31))] == {

--- a/tests/runner/spark_runner_test.py
+++ b/tests/runner/spark_runner_test.py
@@ -23,14 +23,15 @@ def test_only_stream_dtc_provided():
     assert len(block_data) == 8
 
     # Stream DTC output
-    assert block_data[Key('userA', 'session', datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()))] == {
-        '_identity': 'userA',
-        '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
-        '_end_time': datetime(2018, 3, 7, 23, 35, 32, tzinfo=tzutc()),
-        'events': 2,
-        'country': 'IN',
-        'continent': 'World'
-    }
+    assert block_data[Key('userA', 'session',
+                          datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()))] == {
+                              '_identity': 'userA',
+                              '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
+                              '_end_time': datetime(2018, 3, 7, 23, 35, 32, tzinfo=tzutc()),
+                              'events': 2,
+                              'country': 'IN',
+                              'continent': 'World'
+                          }
 
     assert block_data[Key('userA', 'session', datetime(2018, 3, 7, 22, 35, 31))] == {
         '_identity': 'userA',
@@ -44,17 +45,20 @@ def test_only_stream_dtc_provided():
     assert block_data[Key('userA', 'state')] == {
         '_identity': 'userA',
         'country': 'IN',
-        'continent': 'World'
+        'continent': 'World',
+        '_end_time': datetime(2018, 3, 7, 23, 35, 32, tzinfo=tzutc()),
+        '_start_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc())
     }
 
-    assert block_data[Key('userB', 'session', datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()))] == {
-        '_identity': 'userB',
-        '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
-        '_end_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
-        'events': 1,
-        'country': '',
-        'continent': ''
-    }
+    assert block_data[Key('userB', 'session',
+                          datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()))] == {
+                              '_identity': 'userB',
+                              '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
+                              '_end_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()),
+                              'events': 1,
+                              'country': '',
+                              'continent': ''
+                          }
 
 
 def test_no_variable_aggreate_data_stored():


### PR DESCRIPTION
**PR Checklist**

_Please make sure to review and check all of these items:_

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated

**What kind of change does this PR introduce?**

Renamed BlockAggregate to StreamingAggregate and made it into an ABC.

Next PR will remove `LabelAggregate` and merge its functionality into `IdentityAggregate`. Final state will be 3 aggregates supported:
- IdentityAggregate inheriting from StreamingAggregate
- ActivityAggregate inheriting from StreamingAggregate
- WindowAggregate inheriting from Aggregate

Merging this to multi-key-label branch. Will add docs before merging multi-key-label to master.
