### PR TITLE
Adding Expression instanciation errors to ScheamLoader error collection

### DIFF
--- a/blurr/core/aggregate_block.py
+++ b/blurr/core/aggregate_block.py
@@ -16,8 +16,7 @@ class BlockAggregateSchema(AggregateSchema):
         super().__init__(fully_qualified_name, schema_loader)
 
         # Load type specific attributes
-        self.split: Expression = Expression(
-            self._spec[self.ATTRIBUTE_SPLIT]) if self.ATTRIBUTE_SPLIT in self._spec else None
+        self.split: Expression = self.build_expression(self.ATTRIBUTE_SPLIT)
 
     def validate_schema_spec(self) -> None:
         super().validate_schema_spec()

--- a/blurr/core/anchor.py
+++ b/blurr/core/anchor.py
@@ -19,8 +19,7 @@ class AnchorSchema(BaseSchema):
     def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
-        self.condition = Expression(self._spec[
-            self.ATTRIBUTE_CONDITION]) if self.ATTRIBUTE_CONDITION in self._spec else None
+        self.condition = self.build_expression(self.ATTRIBUTE_CONDITION)
         self.max = self._spec[self.ATTRIBUTE_MAX] if self.ATTRIBUTE_MAX in self._spec else None
 
     def validate_schema_spec(self) -> None:

--- a/blurr/core/base.py
+++ b/blurr/core/base.py
@@ -41,7 +41,7 @@ class BaseSchema(ABC):
         """ Builds an expression object.  Adds an error if expression creation has errors. """
 
         expression_string = self._spec.get(attribute, None)
-        if expression_string and not str(expression_string).isspace():
+        if expression_string:
             try:
                 return Expression(str(expression_string))
             except Exception as err:

--- a/blurr/core/errors.py
+++ b/blurr/core/errors.py
@@ -123,10 +123,18 @@ class InvalidExpressionError(InvalidSchemaError):
     """
     Indicates that a python expression specified is either non-compilable, or not allowed
     """
+
     def __init__(self, fully_qualified_name: str, spec: Dict[str, Any], attribute: str,
                  error: Exception, *args, **kwargs):
         super().__init__(fully_qualified_name, spec, attribute, *args, **kwargs)
         self.error = error
+
+    def __str__(self):
+        return '`{attribute}: {value}` in section `{name}` is invalid Python expression. Compilation error: \n{error}'.format(
+            attribute=self.attribute,
+            value=self.spec.get(self.attribute, '*missing*'),
+            name=self.fully_qualified_name,
+            error=str(self.error))
 
 
 class ExpressionEvaluationError(Exception):

--- a/blurr/core/errors.py
+++ b/blurr/core/errors.py
@@ -119,11 +119,14 @@ class InvalidIdentifierError(InvalidSchemaError):
             reason=self.reason.value)
 
 
-class InvalidExpressionError(Exception):
+class InvalidExpressionError(InvalidSchemaError):
     """
     Indicates that a python expression specified is either non-compilable, or not allowed
     """
-    pass
+    def __init__(self, fully_qualified_name: str, spec: Dict[str, Any], attribute: str,
+                 error: Exception, *args, **kwargs):
+        super().__init__(fully_qualified_name, spec, attribute, *args, **kwargs)
+        self.error = error
 
 
 class ExpressionEvaluationError(Exception):

--- a/blurr/core/evaluation.py
+++ b/blurr/core/evaluation.py
@@ -119,10 +119,7 @@ class Expression:
         self.code_string = 'None' if not code_string or code_string.isspace() else code_string
         self.type = expression_type
 
-        try:
-            self.code_object = compile(self.code_string, '<string>', self.type.value)
-        except Exception as e:
-            raise InvalidExpressionError(e)
+        self.code_object = compile(self.code_string, '<string>', self.type.value)
 
     def evaluate(self, evaluation_context: EvaluationContext) -> Any:
         """

--- a/blurr/core/evaluation.py
+++ b/blurr/core/evaluation.py
@@ -112,11 +112,7 @@ class Expression:
         :param code_string: Python code statement
         """
 
-        # For non string single value expressions. Ex: 5, False.
-        code_string = str(code_string)
-
-        # For None / empty code strings
-        self.code_string = 'None' if not code_string or code_string.isspace() else code_string
+        self.code_string = str(code_string)
         self.type = expression_type
 
         self.code_object = compile(self.code_string, '<string>', self.type.value)

--- a/blurr/core/field.py
+++ b/blurr/core/field.py
@@ -24,7 +24,7 @@ class FieldSchema(BaseSchema, ABC):
     def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
-        self.value: Expression = Expression(self._spec.get(self.ATTRIBUTE_VALUE, None))
+        self.value: Expression = self.build_expression(self.ATTRIBUTE_VALUE)
 
     def validate_schema_spec(self) -> None:
         super().validate_schema_spec()

--- a/blurr/core/transformer_streaming.py
+++ b/blurr/core/transformer_streaming.py
@@ -18,10 +18,8 @@ class StreamingTransformerSchema(TransformerSchema):
     def __init__(self, fully_qualified_name: str, schema_loader: SchemaLoader) -> None:
         super().__init__(fully_qualified_name, schema_loader)
 
-        self.identity = Expression(
-            self._spec[self.ATTRIBUTE_IDENTITY]) if self.ATTRIBUTE_IDENTITY in self._spec else None
-        self.time = Expression(
-            self._spec[self.ATTRIBUTE_TIME]) if self.ATTRIBUTE_TIME in self._spec else None
+        self.identity = self.build_expression(self.ATTRIBUTE_IDENTITY)
+        self.time = self.build_expression(self.ATTRIBUTE_TIME)
 
     def validate_schema_spec(self) -> None:
         super().validate_schema_spec()

--- a/tests/core/base_schema_test.py
+++ b/tests/core/base_schema_test.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any
 
 import yaml
-from pytest import fixture
+from pytest import fixture, raises
 
 from blurr.core.base import BaseSchema, BaseSchemaCollection
 from blurr.core.errors import RequiredAttributeError, EmptyAttributeError, InvalidIdentifierError, \
@@ -65,15 +65,17 @@ def test_base_schema_validate_schema_spec_missing_type_and_empty_when(
     assert schema.errors[1].attribute == BaseSchema.ATTRIBUTE_NAME
 
 
-def test_base_schema_bluid_expression_adds_error_on_invalid_expression(schema_spec: Dict[str, Any]):
+def test_base_schema_build_expression_adds_error_on_invalid_expression(schema_spec: Dict[str, Any]):
 
-    schema_spec[BaseSchema.ATTRIBUTE_WHEN] = '`'
+    schema_spec[BaseSchema.ATTRIBUTE_WHEN] = 'a;b'
     schema = get_test_schema(schema_spec)
 
     assert len(schema.errors) == 1
     assert isinstance(schema.errors[0], InvalidExpressionError)
     assert schema.errors[0].attribute == BaseSchema.ATTRIBUTE_WHEN
-    assert schema.errors[0].error is not None
+
+    with raises(InvalidExpressionError, match='`When: a;b` in section `TestField` is invalid Python expression.'):
+        raise schema.errors[0]
 
 
 @fixture
@@ -112,7 +114,7 @@ def test_schema_collection_missing_nested_attribute_adds_error(
 
 
 def test_schema_collection_empty_nested_attribute_adds_error(
-        schema_collection_spec: Dict[str, Any]):
+    schema_collection_spec: Dict[str, Any]):
     del schema_collection_spec['Fields'][0]
     schema_loader = SchemaLoader()
     name = schema_loader.add_schema_spec(schema_collection_spec)

--- a/tests/core/base_schema_test.py
+++ b/tests/core/base_schema_test.py
@@ -4,7 +4,8 @@ import yaml
 from pytest import fixture
 
 from blurr.core.base import BaseSchema, BaseSchemaCollection
-from blurr.core.errors import RequiredAttributeError, EmptyAttributeError, InvalidIdentifierError
+from blurr.core.errors import RequiredAttributeError, EmptyAttributeError, InvalidIdentifierError, \
+    InvalidExpressionError
 from blurr.core.evaluation import Expression, EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
 
@@ -59,9 +60,20 @@ def test_base_schema_validate_schema_spec_missing_type_and_empty_when(
 
     assert len(schema.errors) == 2
     assert isinstance(schema.errors[0], EmptyAttributeError)
-    assert schema.errors[0].attribute == 'When'
+    assert schema.errors[0].attribute == BaseSchema.ATTRIBUTE_WHEN
     assert isinstance(schema.errors[1], InvalidIdentifierError)
-    assert schema.errors[1].attribute == 'Name'
+    assert schema.errors[1].attribute == BaseSchema.ATTRIBUTE_NAME
+
+
+def test_base_schema_bluid_expression_adds_error_on_invalid_expression(schema_spec: Dict[str, Any]):
+
+    schema_spec[BaseSchema.ATTRIBUTE_WHEN] = '`'
+    schema = get_test_schema(schema_spec)
+
+    assert len(schema.errors) == 1
+    assert isinstance(schema.errors[0], InvalidExpressionError)
+    assert schema.errors[0].attribute == BaseSchema.ATTRIBUTE_WHEN
+    assert schema.errors[0].error is not None
 
 
 @fixture

--- a/tests/core/base_schema_test.py
+++ b/tests/core/base_schema_test.py
@@ -38,7 +38,7 @@ def get_test_schema(schema_spec: Dict[str, Any]) -> MockSchema:
     return MockSchema(name, schema_loader)
 
 
-def test_base_schema_with_all_attributes(schema_spec: Dict[str, Any]):
+def test_with_all_attributes(schema_spec: Dict[str, Any]):
     test_schema = get_test_schema(schema_spec)
     assert test_schema.name == schema_spec[BaseSchema.ATTRIBUTE_NAME]
     assert test_schema.type == schema_spec[BaseSchema.ATTRIBUTE_TYPE]
@@ -46,7 +46,7 @@ def test_base_schema_with_all_attributes(schema_spec: Dict[str, Any]):
     assert test_schema.when.evaluate(EvaluationContext())
 
 
-def test_base_schema_with_no_attribute_when(schema_spec: Dict[str, Any]):
+def test_with_no_attribute_when(schema_spec: Dict[str, Any]):
     del schema_spec[BaseSchema.ATTRIBUTE_WHEN]
     test_schema = get_test_schema(schema_spec)
     assert test_schema.name == schema_spec[BaseSchema.ATTRIBUTE_NAME]
@@ -54,7 +54,7 @@ def test_base_schema_with_no_attribute_when(schema_spec: Dict[str, Any]):
     assert test_schema.when is None
 
 
-def test_base_schema_validate_schema_spec_missing_type_and_empty_when(
+def test_validate_schema_spec_missing_type_and_empty_when(
         invalid_schema_spec: Dict[str, Any]):
     schema = get_test_schema(invalid_schema_spec)
 
@@ -65,7 +65,7 @@ def test_base_schema_validate_schema_spec_missing_type_and_empty_when(
     assert schema.errors[1].attribute == BaseSchema.ATTRIBUTE_NAME
 
 
-def test_base_schema_build_expression_adds_error_on_invalid_expression(schema_spec: Dict[str, Any]):
+def test_build_expression_adds_error_on_invalid_expression(schema_spec: Dict[str, Any]):
 
     schema_spec[BaseSchema.ATTRIBUTE_WHEN] = 'a;b'
     schema = get_test_schema(schema_spec)

--- a/tests/core/expression_test.py
+++ b/tests/core/expression_test.py
@@ -96,7 +96,7 @@ def test_expression_user_function() -> None:
 
 def test_invalid_expression() -> None:
     code_string = '{9292#?&@&^'
-    with raises(InvalidExpressionError):
+    with raises(Exception):
         Expression(code_string)
 
 


### PR DESCRIPTION
#### Pull Request Checklist:
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated - N/A

### What kind of change does this PR introduce?
Errors raised during expression construction in the schema objects was raised immediately.  

- Changed `InvalidExpressionError` to inherit from `InvalidSchemaError`
- Built a helper in the base to perform null / empty checks and add any raised error to the error collection
- Removed exception wrapping in the `Expression` construction



#### Link to issue
fixes #159 

