### PR TITLE
Updated README with new mybinder urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/productml-blurr/badge/?version=latest)](http://productml-blurr.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/productml/blurr/badge.svg?branch=master)](https://coveralls.io/github/productml/blurr?branch=master)
 [![PyPI version](https://badge.fury.io/py/blurr.svg)](https://badge.fury.io/py/blurr)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/productml/blurr/master?filepath=docs%2Fexamples%2Fnyse)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/productml/blurr/binder-examples)
 
 # Table of contents
 
@@ -62,7 +62,7 @@ Preparing data for specific use cases using Blurr:
 
 * [Dynamic in-game offers (Offer AI)](docs/examples/offer-ai/offer-ai-walkthrough.md) 
 * [Frequently Bought Together](docs/examples/frequently-bought-together/fbt-walkthrough.md)
-* [New York Stock Exchange Prediction](https://mybinder.org/v2/gh/productml/blurr/master?filepath=docs%2Fexamples%2Fnyse)
+* [New York Stock Exchange Prediction](https://mybinder.org/v2/gh/productml/blurr/binder-examples?filepath=nyse%2Fnyse.ipynb)
 
 # Try Blurr
 


### PR DESCRIPTION
#### Pull Request Checklist:
- [x] Tests for the changes have been added . (N/A)
- [x] Docs have been added / updated

### What kind of change does this PR introduce?
Current MyBinder links in README.md are broken. MyBinder tries to initialise `setup.py` after processing `requirements.txt`. Since it doesn't exist, `setup.py` fails due to dependencies.

Raised an issue in MyBinder: https://github.com/jupyterhub/binderhub/issues/559 

I pushed a [binder-examples](https://github.com/productml/blurr/tree/binder-examples) branch, so examples will live there for the time being.

Seems to be much faster to load than the `master` branch, so we may consider to give this branch a permanent status, or perhaps its own repo.