### PR TITLE
Add timestamp and dimension key type.

### DIFF
--- a/blurr/core/aggregate.py
+++ b/blurr/core/aggregate.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod, abstractproperty
 from typing import Dict, Type, Any
 
 from blurr.core.base import BaseSchemaCollection, BaseItemCollection, BaseItem
@@ -7,7 +7,7 @@ from blurr.core.evaluation import EvaluationContext
 from blurr.core.loader import TypeLoader
 from blurr.core.schema_loader import SchemaLoader
 from blurr.core.store import StoreSchema, Store
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type as DTCType
 from blurr.core.validator import ATTRIBUTE_INTERNAL
 
@@ -89,13 +89,16 @@ class Aggregate(BaseItemCollection, ABC):
         """
         self._persist()
 
-    def _persist(self, timestamp=None) -> None:
+    @property
+    def _key(self):
+        return Key(KeyType.DIMENSION, self._identity, self._name)
+
+    def _persist(self) -> None:
         """
         Persists the current data group
-        :param timestamp: Optional timestamp to include in the Key construction
         """
         if self._store:
-            self._store.save(Key(self._identity, self._name, timestamp), self._snapshot)
+            self._store.save(self._key, self._snapshot)
 
     def __getattr__(self, item: str) -> Any:
         """

--- a/blurr/core/aggregate_block.py
+++ b/blurr/core/aggregate_block.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, List
 from blurr.core.aggregate import Aggregate, AggregateSchema
 from blurr.core.evaluation import Expression
 from blurr.core.schema_loader import SchemaLoader
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 from blurr.core.validator import ATTRIBUTE_INTERNAL
 
@@ -79,11 +80,12 @@ class BlockAggregate(Aggregate):
         if split_should_be_evaluated and self._schema.split.evaluate(
                 self._evaluation_context) is True:
             # Save the current snapshot with the current timestamp
-            self._persist(self._start_time)
+            self._persist()
             # Reset the state of the contents
             self.__init__(self._schema, self._identity, self._evaluation_context)
 
         super().run_evaluate()
 
-    def _persist(self, timestamp=None) -> None:
-        super()._persist(timestamp if timestamp else self._start_time)
+    @property
+    def _key(self):
+        return Key(KeyType.TIMESTAMP, self._identity, self._name, [], self._start_time)

--- a/blurr/core/aggregate_identity.py
+++ b/blurr/core/aggregate_identity.py
@@ -97,5 +97,4 @@ class IdentityAggregate(Aggregate):
                    [str(item.value) for item in self._dimension_fields.values()])
 
     def _persist(self) -> None:
-        # TODO Refactor keys when refactoring store
         self._store.save(self._existing_key, self._snapshot)

--- a/blurr/core/aggregate_window.py
+++ b/blurr/core/aggregate_window.py
@@ -6,7 +6,7 @@ from blurr.core.aggregate_block import BlockAggregate, BlockAggregateSchema
 from blurr.core.errors import PrepareWindowMissingBlocksError
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 
 
@@ -66,13 +66,15 @@ class WindowAggregate(Aggregate):
                 self._schema.window_type, Type.HOUR):
             block_list = self._load_blocks(
                 store.get_range(
-                    Key(self._identity, self._schema.source.name, start_time),
-                    Key(self._identity, self._schema.source.name, self._get_end_time(start_time))))
+                    Key(KeyType.TIMESTAMP, self._identity, self._schema.source.name, [],
+                        start_time),
+                    Key(KeyType.TIMESTAMP, self._identity, self._schema.source.name, [],
+                        self._get_end_time(start_time))))
         else:
             block_list = self._load_blocks(
                 store.get_range(
-                    Key(self._identity, self._schema.source.name, start_time), None,
-                    self._schema.window_value))
+                    Key(KeyType.TIMESTAMP, self._identity, self._schema.source.name, [],
+                        start_time), None, self._schema.window_value))
 
         self._window_source = _WindowSource(block_list)
         self._validate_view()

--- a/blurr/core/loader.py
+++ b/blurr/core/loader.py
@@ -55,6 +55,7 @@ SCHEMA_MAP = {
 
 _class_cache: Dict[str, Type] = {}
 
+
 class TypeLoader:
     @staticmethod
     def load_schema(type_name: Union[str, Type]):

--- a/blurr/core/store_key.py
+++ b/blurr/core/store_key.py
@@ -18,6 +18,7 @@ class Key:
     PARTITION = '/'
     DIMENSION_PARTITION = ':'
 
+    # TODO: Consider adding a * to force parameterization of attributes.
     def __init__(self,
                  key_type: KeyType,
                  identity: str,

--- a/blurr/core/store_key.py
+++ b/blurr/core/store_key.py
@@ -1,6 +1,14 @@
 from datetime import datetime, timezone
+from enum import Enum
+from typing import List, Any
 
 from dateutil import parser
+
+
+class KeyType(Enum):
+    DIMENSION = 1
+    TIMESTAMP = 2
+    UNKNOWN = 10
 
 
 class Key:
@@ -8,8 +16,14 @@ class Key:
     A record in the store is identified by a key
     """
     PARTITION = '/'
+    DIMENSION_PARTITION = ':'
 
-    def __init__(self, identity: str, group: str, timestamp: datetime = None) -> None:
+    def __init__(self,
+                 key_type: KeyType,
+                 identity: str,
+                 group: str,
+                 dimensions: List[Any] = list(),
+                 timestamp: datetime = None) -> None:
         """
         Initializes a new key for storing data
         :param identity: Primary identity of the record being stored
@@ -22,50 +36,92 @@ class Key:
         if not group or group.isspace():
             raise ValueError('`group` must be present.')
 
+        if dimensions and timestamp:
+            raise ValueError('Both dimensions and timestamp should not be set together.')
+
+        if key_type == KeyType.DIMENSION and timestamp:
+            raise ValueError('`timestamp` should not be set for KeyType.DIMENSION.')
+
+        if key_type == KeyType.TIMESTAMP and not timestamp:
+            raise ValueError('`timestamp` should be set for KeyType.TIMESTAMP.')
+
+        self.key_type = key_type
         self.identity = identity
         self.group = group
         self.timestamp = timestamp if not timestamp or timestamp.tzinfo else timestamp.replace(
             tzinfo=timezone.utc)
+        self.dimensions = ':'.join(dimensions) if dimensions else ''
 
     @staticmethod
     def parse(key_string: str) -> 'Key':
         """ Parses a flat key string and returns a key """
         parts = key_string.split(Key.PARTITION)
-        return Key(parts[0], parts[1], parser.parse(parts[2]) if len(parts) > 2 else None)
+        key_type = KeyType.DIMENSION
+        if parts[3]:
+            key_type = KeyType.TIMESTAMP
+        return Key(key_type, parts[0], parts[1], parts[2].split(Key.DIMENSION_PARTITION)
+                   if parts[2] else [],
+                   parser.parse(parts[3]) if parts[3] else None)
+
+    @staticmethod
+    def parse_sort_key(identity: str, sort_key_string: str) -> 'Key':
+        """ Parses a flat key string and returns a key """
+        parts = sort_key_string.split(Key.PARTITION)
+        key_type = KeyType.DIMENSION
+        if parts[2]:
+            key_type = KeyType.TIMESTAMP
+        return Key(key_type, identity, parts[0], parts[1].split(Key.DIMENSION_PARTITION)
+                   if parts[1] else [],
+                   parser.parse(parts[2]) if parts[2] else None)
 
     def __str__(self):
         """ Returns the string representation of the key"""
-        if self.timestamp:
-            return Key.PARTITION.join([self.identity, self.group, self.timestamp.isoformat()])
+        return Key.PARTITION.join([
+            self.identity, self.group, self.dimensions,
+            self.timestamp.isoformat() if self.timestamp else ''
+        ])
 
-        return Key.PARTITION.join([self.identity, self.group])
+    @property
+    def sort_key(self):
+        return Key.PARTITION.join(
+            [self.group, self.dimensions,
+             self.timestamp.isoformat() if self.timestamp else ''])
 
     def __repr__(self):
         return self.__str__()
 
     def __eq__(self, other: 'Key') -> bool:
-        return other and (self.identity, self.group,
-                          self.timestamp) == (other.identity, other.group, other.timestamp)
+        return other and (self.identity, self.group, self.timestamp,
+                          self.dimensions) == (other.identity, other.group, other.timestamp,
+                                               other.dimensions)
 
     def __lt__(self, other: 'Key') -> bool:
         """
         Does a less than comparison on two keys. A None timestamp is considered
         larger than a timestamp that has been set.
         """
-        if (self.identity, self.group) != (other.identity, other.group) or self.timestamp is None:
+        if (self.identity, self.group, self.key_type) != (other.identity, other.group,
+                                                          other.key_type):
             return False
 
-        return (other.timestamp is None) or (self.timestamp < other.timestamp)
+        if self.key_type == KeyType.TIMESTAMP:
+            return self.timestamp < other.timestamp
+
+        return self.dimensions < other.dimensions
 
     def __gt__(self, other: 'Key') -> bool:
         """
         Does a greater than comparison on two keys. A None timestamp is
         considered larger than a timestamp that has been set.
         """
-        if (self.identity, self.group) != (other.identity, other.group) or other.timestamp is None:
+        if (self.identity, self.group, self.key_type) != (other.identity, other.group,
+                                                          other.key_type):
             return False
 
-        return (self.timestamp is None) or (self.timestamp > other.timestamp)
+        if self.key_type == KeyType.TIMESTAMP:
+            return self.timestamp > other.timestamp
+
+        return self.dimensions > other.dimensions
 
     def __hash__(self):
-        return hash((self.identity, self.group, self.timestamp))
+        return hash((self.identity, self.group, self.timestamp, self.dimensions))

--- a/docs/examples/tutorial/tutorial1-output.log
+++ b/docs/examples/tutorial/tutorial1-output.log
@@ -1,3 +1,3 @@
-["09C1/session_stats/2018-03-04T09:01:03+00:00", {"_identity": "09C1", "_start_time": "2018-03-04T09:01:03", "_end_time": "2018-03-04T09:10:22", "session_id": "915D", "games_played": 2, "games_won": 2}]
-["09C1/session_stats/2018-03-04T09:22:13+00:00", {"_identity": "09C1", "_start_time": "2018-03-04T09:22:13", "_end_time": "2018-03-04T09:25:24", "session_id": "T8KA", "games_played": 1, "games_won": 1}]
-["B6FA/session_stats/2018-03-04T09:11:03+00:00", {"_identity": "B6FA", "_start_time": "2018-03-04T09:11:03", "_end_time": "2018-03-04T09:21:55", "session_id": "D043", "games_played": 1, "games_won": 1}]
+["09C1/session_stats//2018-03-04T09:01:03+00:00", {"_identity": "09C1", "_start_time": "2018-03-04T09:01:03", "_end_time": "2018-03-04T09:10:22", "session_id": "915D", "games_played": 2, "games_won": 2}]
+["09C1/session_stats//2018-03-04T09:22:13+00:00", {"_identity": "09C1", "_start_time": "2018-03-04T09:22:13", "_end_time": "2018-03-04T09:25:24", "session_id": "T8KA", "games_played": 1, "games_won": 1}]
+["B6FA/session_stats//2018-03-04T09:11:03+00:00", {"_identity": "B6FA", "_start_time": "2018-03-04T09:11:03", "_end_time": "2018-03-04T09:21:55", "session_id": "D043", "games_played": 1, "games_won": 1}]

--- a/tests/cli/transform_test.py
+++ b/tests/cli/transform_test.py
@@ -64,7 +64,7 @@ def test_transform_only_stream(capsys, runner) -> None:
         runner=runner) == 0
     out, err = capsys.readouterr()
     assert_record_in_ouput([
-        'userA/session/2018-03-07T22:35:31+00:00', {
+        'userA/session//2018-03-07T22:35:31+00:00', {
             '_identity': 'userA',
             '_start_time': '2018-03-07T22:35:31+00:00',
             '_end_time': '2018-03-07T22:35:31+00:00',
@@ -74,13 +74,13 @@ def test_transform_only_stream(capsys, runner) -> None:
         }
     ], out)
     assert_record_in_ouput(
-        ['userA/state', {
+        ['userA/state//', {
             '_identity': 'userA',
             'country': 'IN',
             'continent': 'World'
         }], out)
     assert_record_in_ouput([
-        'userA/session/2018-03-07T23:35:31+00:00', {
+        'userA/session//2018-03-07T23:35:31+00:00', {
             '_identity': 'userA',
             '_start_time': '2018-03-07T23:35:31+00:00',
             '_end_time': '2018-03-07T23:35:32+00:00',

--- a/tests/core/aggregate_activity_test.py
+++ b/tests/core/aggregate_activity_test.py
@@ -9,7 +9,7 @@ from blurr.core.errors import RequiredAttributeError, InvalidNumberError
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.record import Record
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 
 
@@ -100,31 +100,34 @@ def test_aggregate_final_state(activity_aggregate_schema: ActivityAggregateSchem
     store_state = activity_aggregate._store.get_all(identity)
     assert len(store_state) == 3
     assert store_state.get(
-        Key('user1', 'activity_aggr', datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc))) == {
-            '_identity': 'user1',
-            '_start_time': datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc).isoformat(),
-            '_end_time': datetime(2018, 1, 1, 1, 2, 1, 0, timezone.utc).isoformat(),
-            'sum': 111,
-            'count': 3
-        }
+        Key(KeyType.TIMESTAMP, 'user1', 'activity_aggr', [],
+            datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc))) == {
+                '_identity': 'user1',
+                '_start_time': datetime(2018, 1, 1, 1, 1, 1, 0, timezone.utc).isoformat(),
+                '_end_time': datetime(2018, 1, 1, 1, 2, 1, 0, timezone.utc).isoformat(),
+                'sum': 111,
+                'count': 3
+            }
 
     assert store_state.get(
-        Key('user1', 'activity_aggr', datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc))) == {
-            '_identity': 'user1',
-            '_start_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc).isoformat(),
-            '_end_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc).isoformat(),
-            'sum': 1000,
-            'count': 1
-        }
+        Key(KeyType.TIMESTAMP, 'user1', 'activity_aggr', [],
+            datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc))) == {
+                '_identity': 'user1',
+                '_start_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc).isoformat(),
+                '_end_time': datetime(2018, 1, 1, 3, 1, 1, 0, timezone.utc).isoformat(),
+                'sum': 1000,
+                'count': 1
+            }
 
     assert store_state.get(
-        Key('user1', 'activity_aggr', datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc))) == {
-            '_identity': 'user1',
-            '_start_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc).isoformat(),
-            '_end_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc).isoformat(),
-            'sum': 10000,
-            'count': 1
-        }
+        Key(KeyType.TIMESTAMP, 'user1', 'activity_aggr', [],
+            datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc))) == {
+                '_identity': 'user1',
+                '_start_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc).isoformat(),
+                '_end_time': datetime(2018, 1, 2, 1, 1, 1, 0, timezone.utc).isoformat(),
+                'sum': 10000,
+                'count': 1
+            }
 
 
 def test_evaluate_no_separation(activity_aggregate_schema: ActivityAggregateSchema,

--- a/tests/core/aggregate_block_test.py
+++ b/tests/core/aggregate_block_test.py
@@ -8,7 +8,7 @@ from blurr.core.aggregate_block import BlockAggregateSchema, \
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.field import Field
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 
 
@@ -81,7 +81,8 @@ def test_block_aggregate_schema_evaluate_without_split(block_aggregate_schema_sp
 
     # aggregate snapshot should not exist in store
     assert block_aggregate._store.get(
-        Key(identity=block_aggregate._identity,
+        Key(key_type=KeyType.TIMESTAMP,
+            identity=block_aggregate._identity,
             group=block_aggregate._name,
             timestamp=block_aggregate._start_time)) is None
 
@@ -118,5 +119,8 @@ def test_block_aggregate_schema_evaluate_with_split(block_aggregate_schema_spec,
 
     # Check aggregate snapshot present in store
     assert block_aggregate._store.get(
-        Key(identity=block_aggregate._identity, group=block_aggregate._name,
+        Key(key_type=KeyType.TIMESTAMP,
+            identity=block_aggregate._identity,
+            group=block_aggregate._name,
+            dimensions=[],
             timestamp=time)) == current_snapshot

--- a/tests/core/aggregate_identity_test.py
+++ b/tests/core/aggregate_identity_test.py
@@ -8,7 +8,7 @@ from blurr.core.evaluation import EvaluationContext
 from blurr.core.record import Record
 from blurr.core.schema_loader import SchemaLoader
 from blurr.core.store import StoreSchema
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 
 
@@ -164,21 +164,21 @@ def test_split_by_label_valid(identity_aggregate_schema_spec: Dict[str, Any],
     store_state = identity_aggregate._store.get_all(identity)
     assert len(store_state) == 3
 
-    assert store_state.get(Key('user1', 'label_aggr.a')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['a'])) == {
         '_identity': 'user1',
         'label': 'a',
         'sum': 110,
         'count': 2
     }
 
-    assert store_state.get(Key('user1', 'label_aggr.b')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['b'])) == {
         '_identity': 'user1',
         'label': 'b',
         'sum': 1,
         'count': 1
     }
 
-    assert store_state.get(Key('user1', 'label_aggr.c')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['c'])) == {
         '_identity': 'user1',
         'label': 'c',
         'sum': 11000,
@@ -209,7 +209,7 @@ def test_split_when_label_evaluates_to_none(identity_aggregate_schema_spec: Dict
     store_state = identity_aggregate._store.get_all(identity)
     assert len(store_state) == 1
 
-    assert store_state.get(Key('user1', 'label_aggr.b')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['b'])) == {
         '_identity': 'user1',
         'label': 'b',
         'sum': 1,
@@ -238,7 +238,7 @@ def test_two_key_fields_in_aggregate(
     store_state = identity_aggregate._store.get_all('user1')
     assert len(store_state) == 3
 
-    assert store_state.get(Key('user1', 'label_aggr.a:97')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['a', '97'])) == {
         '_identity': 'user1',
         'label': 'a',
         'label_ascii': 97,
@@ -246,7 +246,7 @@ def test_two_key_fields_in_aggregate(
         'count': 2
     }
 
-    assert store_state.get(Key('user1', 'label_aggr.b:98')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['b', '98'])) == {
         '_identity': 'user1',
         'label': 'b',
         'label_ascii': 98,
@@ -254,7 +254,7 @@ def test_two_key_fields_in_aggregate(
         'count': 1
     }
 
-    assert store_state.get(Key('user1', 'label_aggr.c:99')) == {
+    assert store_state.get(Key(KeyType.DIMENSION, 'user1', 'label_aggr', ['c', '99'])) == {
         '_identity': 'user1',
         'label': 'c',
         'label_ascii': 99,

--- a/tests/core/aggregate_test.py
+++ b/tests/core/aggregate_test.py
@@ -7,7 +7,7 @@ from blurr.core.aggregate import AggregateSchema, Aggregate
 from blurr.core.evaluation import EvaluationContext
 from blurr.core.field import Field
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 
 
@@ -87,10 +87,9 @@ def test_aggregate_persist_with_store(aggregate_schema_with_store):
         schema=aggregate_schema_with_store,
         identity="12345",
         evaluation_context=EvaluationContext())
-    dt = datetime.now()
-    dt.replace(tzinfo=timezone.utc)
-    aggregate._persist(dt)
-    snapshot_aggregate = aggregate._store.get(Key(identity="12345", group="user", timestamp=dt))
+    aggregate._persist()
+    snapshot_aggregate = aggregate._store.get(
+        Key(KeyType.DIMENSION, identity="12345", group="user"))
     assert snapshot_aggregate is not None
     assert snapshot_aggregate == aggregate._snapshot
 
@@ -101,6 +100,7 @@ def test_aggregate_finalize(aggregate_schema_with_store):
         identity="12345",
         evaluation_context=EvaluationContext())
     aggregate.run_finalize()
-    snapshot_aggregate = aggregate._store.get(Key(identity="12345", group="user"))
+    snapshot_aggregate = aggregate._store.get(
+        Key(KeyType.DIMENSION, identity="12345", group="user"))
     assert snapshot_aggregate is not None
     assert snapshot_aggregate == aggregate._snapshot

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from pytest import fixture
 
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 from blurr.store.memory_store import MemoryStore
 
@@ -31,22 +31,51 @@ def schema_loader_with_mem_store(stream_dtc_name: str) -> SchemaLoader:
 
 
 def init_memory_store(store: MemoryStore) -> None:
-    store.save(Key('user1', 'state'), {'variable_1': 1, 'variable_a': 'a', 'variable_true': True})
+    store.save(
+        Key(KeyType.DIMENSION, 'user1', 'state'), {
+            'variable_1': 1,
+            'variable_a': 'a',
+            'variable_true': True
+        })
 
     date = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
-    store.save(Key('user1', 'session', date), {'events': 1, '_start_time': date.isoformat()})
+    store.save(
+        Key(KeyType.TIMESTAMP, 'user1', 'session', [], date), {
+            'events': 1,
+            '_start_time': date.isoformat()
+        })
 
     date = datetime(2018, 3, 7, 20, 35, 35, 0, timezone.utc)
-    store.save(Key('user1', 'session', date), {'events': 2, '_start_time': date.isoformat()})
+    store.save(
+        Key(KeyType.TIMESTAMP, 'user1', 'session', [], date), {
+            'events': 2,
+            '_start_time': date.isoformat()
+        })
 
     date = datetime(2018, 3, 7, 21, 36, 31, 0, timezone.utc)
-    store.save(Key('user1', 'session', date), {'events': 3, '_start_time': date.isoformat()})
+    store.save(
+        Key(KeyType.TIMESTAMP, 'user1', 'session', [], date), {
+            'events': 3,
+            '_start_time': date.isoformat()
+        })
 
     date = datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc)
-    store.save(Key('user1', 'session', date), {'events': 4, '_start_time': date.isoformat()})
+    store.save(
+        Key(KeyType.TIMESTAMP, 'user1', 'session', [], date), {
+            'events': 4,
+            '_start_time': date.isoformat()
+        })
 
     date = datetime(2018, 3, 7, 23, 40, 31, 0, timezone.utc)
-    store.save(Key('user1', 'session', date), {'events': 5, '_start_time': date.isoformat()})
+    store.save(
+        Key(KeyType.TIMESTAMP, 'user1', 'session', [], date), {
+            'events': 5,
+            '_start_time': date.isoformat()
+        })
 
     date = datetime(2018, 3, 8, 23, 40, 31, 0, timezone.utc)
-    store.save(Key('user1', 'session'), {'events': 6, '_start_time': date.isoformat()})
+    store.save(
+        Key(KeyType.TIMESTAMP, 'user1', 'session', [], date), {
+            'events': 6,
+            '_start_time': date.isoformat()
+        })

--- a/tests/core/key_test.py
+++ b/tests/core/key_test.py
@@ -2,29 +2,44 @@ from datetime import datetime
 
 import pytest
 
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 
 
 def test_invalid_identity():
     with pytest.raises(ValueError, match='`identity` must be present.'):
-        Key('', 'group')
+        Key(KeyType.DIMENSION, '', 'group')
 
     with pytest.raises(ValueError, match='`identity` must be present.'):
-        Key(None, 'group')
+        Key(KeyType.DIMENSION, None, 'group')
 
 
 def test_invalid_group():
     with pytest.raises(ValueError, match='`group` must be present.'):
-        Key('id', '')
+        Key(KeyType.DIMENSION, 'id', '')
 
     with pytest.raises(ValueError, match='`group` must be present.'):
-        Key('id', None)
+        Key(KeyType.DIMENSION, 'id', None)
+
+
+def test_both_timestamp_and_dimension_error():
+    with pytest.raises(
+            ValueError, match='Both dimensions and timestamp should not be set together.'):
+        Key(KeyType.DIMENSION, 'id', 'group', ['dim1'], datetime(2018, 3, 7, 22, 35, 31))
+
+
+def test_key_type_and_args_error():
+    with pytest.raises(ValueError, match='`timestamp` should not be set for KeyType.DIMENSION.'):
+        Key(KeyType.DIMENSION, 'id', 'group', [], datetime(2018, 3, 7, 22, 35, 31))
+
+    with pytest.raises(ValueError, match='`timestamp` should be set for KeyType.TIMESTAMP.'):
+        Key(KeyType.TIMESTAMP, 'id', 'group', ['dim1'], None)
 
 
 def test_parse():
-    assert Key.parse('a/b/2018-03-07T22:35:31+00:00') == Key('a', 'b',
-                                                             datetime(2018, 3, 7, 22, 35, 31))
-    assert Key.parse('a/b') == Key('a', 'b', None)
+    assert Key.parse('a/b//2018-03-07T22:35:31+00:00') == Key(KeyType.TIMESTAMP, 'a', 'b', [],
+                                                              datetime(2018, 3, 7, 22, 35, 31))
+    assert Key.parse('a/b/c:d/') == Key(KeyType.DIMENSION, 'a', 'b', ['c', 'd'])
+    assert Key.parse('a/b//') == Key(KeyType.DIMENSION, 'a', 'b')
     with pytest.raises(Exception):
         Key.parse('')
     with pytest.raises(Exception):
@@ -35,37 +50,56 @@ def test_parse():
         Key.parse('None')
 
 
-def test_equals():
-    assert Key('a', 'b') == Key('a', 'b')
-    assert Key('a', 'b') != Key('a', 'c')
-    assert Key('a', 'b') != Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31))
-    assert Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) == Key('a', 'b',
-                                                                  datetime(2018, 3, 7, 22, 35, 31))
-    assert Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) != Key('a', 'b',
-                                                                  datetime(2018, 3, 6, 22, 35, 31))
+def test_equals_dimension_key():
+    assert Key(KeyType.DIMENSION, 'a', 'b') == Key(KeyType.DIMENSION, 'a', 'b')
+    assert Key(KeyType.DIMENSION, 'a', 'b') != Key(KeyType.DIMENSION, 'a', 'c')
+    assert Key(KeyType.DIMENSION, 'a', 'b') != Key(KeyType.DIMENSION, 'a', 'b', ['c'])
+    assert Key(KeyType.DIMENSION, 'a', 'b', ['c']) == Key(KeyType.DIMENSION, 'a', 'b', ['c'])
+    assert Key(KeyType.DIMENSION, 'a', 'b', ['c']) != Key(KeyType.DIMENSION, 'a', 'b', ['d'])
 
 
-def test_greater_than():
-    assert (Key('a', 'b') > Key('a', 'b')) is False
-    assert (Key('a', 'b') > Key('a', 'c')) is False
-    assert (Key('a', 'b') > Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is True
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key('a', 'b')) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key(
-        'a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key(
-        'a', 'b', datetime(2018, 3, 8, 22, 35, 31))) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) > Key(
-        'a', 'b', datetime(2018, 3, 6, 22, 35, 31))) is True
+def test_equals_timestamp_key():
+    assert Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) == Key(
+        KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31))
+    assert Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) != Key(
+        KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 6, 22, 35, 31))
+    assert Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) != Key(
+        KeyType.TIMESTAMP, 'a', 'c', [], datetime(2018, 3, 7, 22, 35, 31))
 
 
-def test_less_than():
-    assert (Key('a', 'b') < Key('a', 'b')) is False
-    assert (Key('a', 'b') < Key('a', 'c')) is False
-    assert (Key('a', 'b') < Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key('a', 'b')) is True
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key(
-        'a', 'b', datetime(2018, 3, 7, 22, 35, 31))) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key(
-        'a', 'b', datetime(2018, 3, 6, 22, 35, 31))) is False
-    assert (Key('a', 'b', datetime(2018, 3, 7, 22, 35, 31)) < Key(
-        'a', 'b', datetime(2018, 3, 8, 22, 35, 31))) is True
+def test_greater_than_dimension_key():
+    assert (Key(KeyType.DIMENSION, 'a', 'b') > Key(KeyType.DIMENSION, 'a', 'b')) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b') > Key(KeyType.DIMENSION, 'a', 'c')) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b') > Key(KeyType.DIMENSION, 'a', 'b', ['c'])) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b', ['c']) > Key(KeyType.DIMENSION, 'a', 'b',
+                                                          ['c'])) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b', ['d']) > Key(KeyType.DIMENSION, 'a', 'b',
+                                                          ['c'])) is True
+
+
+def test_greater_than_timestamp_key():
+    assert (Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) > Key(
+        KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31))) is False
+    assert (Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) > Key(
+        KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 6, 22, 35, 31))) is True
+    assert (Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) > Key(
+        KeyType.TIMESTAMP, 'a', 'c', [], datetime(2018, 3, 7, 22, 35, 31))) is False
+
+
+def test_less_than_dimension_key():
+    assert (Key(KeyType.DIMENSION, 'a', 'b') < Key(KeyType.DIMENSION, 'a', 'b')) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b') < Key(KeyType.DIMENSION, 'a', 'c')) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b') < Key(KeyType.DIMENSION, 'a', 'b', ['c'])) is True
+    assert (Key(KeyType.DIMENSION, 'a', 'b', ['c']) < Key(KeyType.DIMENSION, 'a', 'b',
+                                                          ['c'])) is False
+    assert (Key(KeyType.DIMENSION, 'a', 'b', ['c']) < Key(KeyType.DIMENSION, 'a', 'b',
+                                                          ['d'])) is True
+
+
+def test_less_than_timestamp_key():
+    assert (Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) < Key(
+        KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31))) is False
+    assert (Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 6, 22, 35, 31)) < Key(
+        KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31))) is True
+    assert (Key(KeyType.TIMESTAMP, 'a', 'b', [], datetime(2018, 3, 7, 22, 35, 31)) < Key(
+        KeyType.TIMESTAMP, 'a', 'c', [], datetime(2018, 3, 7, 22, 35, 31))) is False

--- a/tests/core/store_test.py
+++ b/tests/core/store_test.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from pytest import fixture
 
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.type import Type
 from blurr.store.memory_store import MemoryStore
 
@@ -21,11 +21,11 @@ def empty_memory_store() -> MemoryStore:
 
 
 def test_get(memory_store: MemoryStore) -> None:
-    key = Key('user1', 'state')
+    key = Key(KeyType.DIMENSION, 'user1', 'state')
     assert memory_store.get(key) == {'variable_1': 1, 'variable_a': 'a', 'variable_true': True}
 
     date = datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc)
-    key = Key('user1', 'session', date)
+    key = Key(KeyType.TIMESTAMP, 'user1', 'session', [], date)
     assert memory_store.get(key) == {'events': 1, '_start_time': date.isoformat()}
 
 
@@ -35,9 +35,9 @@ def test_set_simple(empty_memory_store) -> None:
     :return:
     """
     store = empty_memory_store
-    store.save(Key('test_user', 'test_group'), 1)
+    store.save(Key(KeyType.DIMENSION, 'test_user', 'test_group'), 1)
 
-    assert store.get(Key('test_user', 'test_group')) == 1
+    assert store.get(Key(KeyType.DIMENSION, 'test_user', 'test_group')) == 1
 
 
 def test_set_get_date(empty_memory_store) -> None:
@@ -46,18 +46,20 @@ def test_set_get_date(empty_memory_store) -> None:
     """
     store = empty_memory_store
     now = datetime.utcnow()
-    key = Key('user1', 'session', now)
+    key = Key(KeyType.TIMESTAMP, 'user1', 'session', [], now)
     store.save(key, 'test')
 
-    assert store.get(Key('user1', 'session', now)) == 'test'
+    assert store.get(Key(KeyType.TIMESTAMP, 'user1', 'session', [], now)) == 'test'
 
 
 def test_get_range_start_end(memory_store: MemoryStore) -> None:
     """
     Tests that the range get does not include the blocks that lie on the boundary
     """
-    start = Key('user1', 'session', datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
-    end = Key('user1', 'session', datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
+    start = Key(KeyType.TIMESTAMP, 'user1', 'session', [],
+                datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
+    end = Key(KeyType.TIMESTAMP, 'user1', 'session', [],
+              datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
     blocks = memory_store.get_range(start, end)
     assert len(blocks) == 2
     assert blocks[0][1]['_start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0,
@@ -68,7 +70,8 @@ def test_get_range_start_count(memory_store: MemoryStore) -> None:
     """
     Tests that the range get does not include the blocks that lie on the boundary
     """
-    start = Key('user1', 'session', datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
+    start = Key(KeyType.TIMESTAMP, 'user1', 'session', [],
+                datetime(2018, 3, 7, 19, 35, 31, 0, timezone.utc))
     blocks = memory_store.get_range(start, None, 2)
     assert len(blocks) == 2
     assert blocks[0][1]['_start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0,
@@ -79,7 +82,8 @@ def test_get_range_end_count(memory_store: MemoryStore) -> None:
     """
     Tests that the range get does not include the blocks that lie on the boundary
     """
-    end = Key('user1', 'session', datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
+    end = Key(KeyType.TIMESTAMP, 'user1', 'session', [],
+              datetime(2018, 3, 7, 22, 38, 31, 0, timezone.utc))
     blocks = memory_store.get_range(end, None, -2)
     assert len(blocks) == 2
     assert blocks[0][1]['_start_time'] == datetime(2018, 3, 7, 20, 35, 35, 0,

--- a/tests/core/transformer_streaming_test.py
+++ b/tests/core/transformer_streaming_test.py
@@ -9,7 +9,7 @@ from blurr.core.errors import IdentityError, TimeError, RequiredAttributeError
 from blurr.core.evaluation import Context
 from blurr.core.record import Record
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.transformer_streaming import StreamingTransformerSchema, StreamingTransformer
 from blurr.core.type import Type
 
@@ -144,11 +144,14 @@ def test_streaming_transformer_finalize(schema_loader: SchemaLoader,
     store = schema_loader.get_store('test.memstore')
 
     transformer.run_finalize()
-    assert store.get(Key('user1', 'test_group')) is None
+    assert store.get(Key(KeyType.DIMENSION, 'user1', 'test_group')) is None
 
     transformer.run_evaluate(Record())
     transformer.run_finalize()
-    assert store.get(Key('user1', 'test_group')) == {'_identity': 'user1', 'events': 1}
+    assert store.get(Key(KeyType.DIMENSION, 'user1', 'test_group')) == {
+        '_identity': 'user1',
+        'events': 1
+    }
 
 
 def test_streaming_transformer_schema_missing_attributes_adds_error(schema_loader: SchemaLoader,

--- a/tests/core/transformer_window_test.py
+++ b/tests/core/transformer_window_test.py
@@ -9,7 +9,7 @@ from blurr.core.anchor import AnchorSchema
 from blurr.core.errors import PrepareWindowMissingBlocksError, RequiredAttributeError
 from blurr.core.evaluation import Context
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.core.transformer_streaming import StreamingTransformer
 from blurr.core.transformer_window import WindowTransformer, WindowTransformerSchema
 from blurr.core.type import Type
@@ -36,7 +36,7 @@ def stream_transformer(schema_loader, stream_schema_spec):
     stream_dtc_name = schema_loader.add_schema_spec(stream_schema_spec)
     stream_transformer = StreamingTransformer(
         schema_loader.get_schema_object(stream_dtc_name), 'user1')
-    stream_transformer.run_restore({Key('user1', 'state'): {'country': 'US'}})
+    stream_transformer.run_restore({Key(KeyType.DIMENSION, 'user1', 'state'): {'country': 'US'}})
     return stream_transformer
 
 

--- a/tests/core/validator_test.py
+++ b/tests/core/validator_test.py
@@ -73,7 +73,7 @@ def test_validate_python_identifier_attributes_with_error_conditions(invalid_spe
     with raises(
             InvalidIdentifierError,
             match='`Identity1: _illegal_identity` in section `test` is invalid. '
-                  'Identifiers starting with underscore `_` are reserved.',
+            'Identifiers starting with underscore `_` are reserved.',
             message='Message does not correctly reflect the reason'):
         raise error
 
@@ -83,7 +83,7 @@ def test_validate_python_identifier_attributes_with_error_conditions(invalid_spe
     with raises(
             InvalidIdentifierError,
             match='`Identity2: some space` in section `test` is invalid. '
-                  'Identifiers must be valid Python identifiers.',
+            'Identifiers must be valid Python identifiers.',
             message='Message does not correctly reflect the reason'):
         raise error
 
@@ -93,7 +93,7 @@ def test_validate_python_identifier_attributes_with_error_conditions(invalid_spe
     with raises(
             InvalidIdentifierError,
             match='`Identity3: run_reserved` in section `test` is invalid. '
-                  'Identifiers starting with `run_` are reserved.',
+            'Identifiers starting with `run_` are reserved.',
             message='Message does not correctly reflect the reason'):
         raise error
 
@@ -113,7 +113,7 @@ def test_validate_empty_attributes():
             message='Error message did not match expected pattern'):
         raise errors[0]
 
- 
+
 def test_validate_enum_attribute(invalid_spec):
     error = validate_enum_attribute('test', invalid_spec, 'Identity3',
                                     {'candidate1', 'candidate2', 'candidate3'})

--- a/tests/extended/extended_test.py
+++ b/tests/extended/extended_test.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.runner.local_runner import LocalRunner
 
 
@@ -12,7 +12,8 @@ def test_extended_runner():
     assert len(local_runner._per_user_data) == 1
     assert len(local_runner._per_user_data['user-1'][0]) == 5
 
-    result_state = local_runner._per_user_data['user-1'][0][Key('user-1', 'state')]
+    result_state = local_runner._per_user_data['user-1'][0][Key(KeyType.DIMENSION, 'user-1',
+                                                                'state')]
     expected_state = {
         '_identity': 'user-1',
         'country': 'US',
@@ -36,7 +37,8 @@ def test_extended_runner():
 
     assert result_state == expected_state
 
-    result_session = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                  'session', [],
                                                                   datetime(2016, 2, 13, 0, 0, 58))]
     expected_session = {
         '_identity': 'user-1',
@@ -54,7 +56,8 @@ def test_extended_runner():
     }
     assert result_session == expected_session
 
-    result_session_10 = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session_10 = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                     'session', [],
                                                                      datetime(2016, 2, 10, 0, 0))]
     expected_session_10 = {
         '_identity': 'user-1',
@@ -73,7 +76,8 @@ def test_extended_runner():
 
     assert result_session_10 == expected_session_10
 
-    result_session_11 = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session_11 = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                     'session', [],
                                                                      datetime(2016, 2, 11, 0, 0))]
     expected_session_11 = {
         '_identity': 'user-1',
@@ -92,7 +96,8 @@ def test_extended_runner():
 
     assert result_session_11 == expected_session_11
 
-    result_session_12 = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session_12 = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                     'session', [],
                                                                      datetime(2016, 2, 12, 0, 0))]
     expected_session_12 = {
         '_identity': 'user-1',

--- a/tests/runner/local_runner_test.py
+++ b/tests/runner/local_runner_test.py
@@ -3,7 +3,7 @@ from typing import List, Tuple, Any, Optional, Dict
 
 from dateutil.tz import tzutc
 
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.runner.local_runner import LocalRunner
 
 
@@ -21,38 +21,41 @@ def test_only_stream_dtc_provided():
     assert len(data) == 3
 
     # Stream DTC output
-    assert data['userA'][0][Key('userA', 'session', datetime(2018, 3, 7, 23, 35, 31))] == {
+    assert data['userA'][0][Key(
+        KeyType.TIMESTAMP, 'userA', 'session', [], datetime(2018, 3, 7, 23, 35, 31))] == {
+            '_identity': 'userA',
+            '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()).isoformat(),
+            '_end_time': datetime(2018, 3, 7, 23, 35, 32, tzinfo=tzutc()).isoformat(),
+            'events': 2,
+            'country': 'IN',
+            'continent': 'World'
+        }
+
+    assert data['userA'][0][Key(
+        KeyType.TIMESTAMP, 'userA', 'session', [], datetime(2018, 3, 7, 22, 35, 31))] == {
+            '_identity': 'userA',
+            '_start_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
+            '_end_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
+            'events': 1,
+            'country': 'US',
+            'continent': 'North America'
+        }
+
+    assert data['userA'][0][Key(KeyType.DIMENSION, 'userA', 'state')] == {
         '_identity': 'userA',
-        '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()).isoformat(),
-        '_end_time': datetime(2018, 3, 7, 23, 35, 32, tzinfo=tzutc()).isoformat(),
-        'events': 2,
         'country': 'IN',
         'continent': 'World'
     }
 
-    assert data['userA'][0][Key('userA', 'session', datetime(2018, 3, 7, 22, 35, 31))] == {
-        '_identity': 'userA',
-        '_start_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
-        '_end_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
-        'events': 1,
-        'country': 'US',
-        'continent': 'North America'
-    }
-
-    assert data['userA'][0][Key('userA', 'state')] == {
-        '_identity': 'userA',
-        'country': 'IN',
-        'continent': 'World'
-    }
-
-    assert data['userB'][0][Key('userB', 'session', datetime(2018, 3, 7, 23, 35, 31))] == {
-        '_identity': 'userB',
-        '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()).isoformat(),
-        '_end_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()).isoformat(),
-        'events': 1,
-        'country': '',
-        'continent': ''
-    }
+    assert data['userB'][0][Key(
+        KeyType.TIMESTAMP, 'userB', 'session', [], datetime(2018, 3, 7, 23, 35, 31))] == {
+            '_identity': 'userB',
+            '_start_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()).isoformat(),
+            '_end_time': datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()).isoformat(),
+            'events': 1,
+            'country': '',
+            'continent': ''
+        }
 
     for (_, window_data) in runner._per_user_data.values():
         assert window_data == []
@@ -62,7 +65,7 @@ def test_no_variable_aggreate_data_stored():
     runner, data = execute_runner('tests/data/stream.yml', None, ['tests/data/raw.json'])
 
     # Variables should not be stored
-    assert Key('userA', 'vars') not in data
+    assert Key(KeyType.DIMENSION, 'userA', 'vars') not in data
 
 
 def test_stream_and_window_dtc_provided():
@@ -115,7 +118,7 @@ def test_write_output_file_only_source_dtc_provided(tmpdir):
     output_file = tmpdir.join('out.txt')
     runner.write_output_file(str(output_file), data)
     output_text = output_file.readlines(cr=False)
-    assert ('["userA/session/2018-03-07T22:35:31+00:00", {'
+    assert ('["userA/session//2018-03-07T22:35:31+00:00", {'
             '"_identity": "userA", '
             '"_start_time": "2018-03-07T22:35:31+00:00", '
             '"_end_time": "2018-03-07T22:35:31+00:00", '

--- a/tests/runner/spark_runner_test.py
+++ b/tests/runner/spark_runner_test.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Any, Optional, Dict
 
 from dateutil.tz import tzutc
 
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.runner.spark_runner import SparkRunner, get_spark_session
 
 
@@ -38,7 +38,7 @@ def test_only_stream_dtc_provided():
     assert len(block_data) == 3
 
     # Stream DTC output
-    assert block_data['userA'][Key('userA', 'session',
+    assert block_data['userA'][Key(KeyType.TIMESTAMP, 'userA', 'session', [],
                                    datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()))] == {
                                        '_identity': 'userA',
                                        '_start_time': datetime(
@@ -50,22 +50,25 @@ def test_only_stream_dtc_provided():
                                        'continent': 'World'
                                    }
 
-    assert block_data['userA'][Key('userA', 'session', datetime(2018, 3, 7, 22, 35, 31))] == {
-        '_identity': 'userA',
-        '_start_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
-        '_end_time': datetime(2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
-        'events': 1,
-        'country': 'US',
-        'continent': 'North America'
-    }
+    assert block_data['userA'][Key(KeyType.TIMESTAMP, 'userA', 'session', [],
+                                   datetime(2018, 3, 7, 22, 35, 31))] == {
+                                       '_identity': 'userA',
+                                       '_start_time': datetime(
+                                           2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
+                                       '_end_time': datetime(
+                                           2018, 3, 7, 22, 35, 31, tzinfo=tzutc()).isoformat(),
+                                       'events': 1,
+                                       'country': 'US',
+                                       'continent': 'North America'
+                                   }
 
-    assert block_data['userA'][Key('userA', 'state')] == {
+    assert block_data['userA'][Key(KeyType.DIMENSION, 'userA', 'state')] == {
         '_identity': 'userA',
         'country': 'IN',
         'continent': 'World'
     }
 
-    assert block_data['userB'][Key('userB', 'session',
+    assert block_data['userB'][Key(KeyType.TIMESTAMP, 'userB', 'session', [],
                                    datetime(2018, 3, 7, 23, 35, 31, tzinfo=tzutc()))] == {
                                        '_identity': 'userB',
                                        '_start_time': datetime(
@@ -87,7 +90,7 @@ def test_no_variable_aggreate_data_stored():
         block_data[id] = per_id_block_data
 
     # Variables should not be stored
-    assert Key('userA', 'vars') not in block_data['userA']
+    assert Key(KeyType.DIMENSION, 'userA', 'vars') not in block_data['userA']
 
 
 def test_stream_and_window_dtc_provided():
@@ -142,7 +145,7 @@ def test_write_output_file_only_source_dtc_provided(tmpdir):
     out_dir = tmpdir.join('out')
     runner.write_output_file(str(out_dir), data)
     output_text = get_spark_output(out_dir)
-    assert ('["userA/session/2018-03-07T22:35:31+00:00", {'
+    assert ('["userA/session//2018-03-07T22:35:31+00:00", {'
             '"_identity": "userA", '
             '"_start_time": "2018-03-07T22:35:31+00:00", '
             '"_end_time": "2018-03-07T22:35:31+00:00", '

--- a/tests/store/dynamo/dynamo_extended_test.py
+++ b/tests/store/dynamo/dynamo_extended_test.py
@@ -5,7 +5,7 @@ from unittest import mock
 import boto3
 from botocore.exceptions import ClientError
 
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.runner.local_runner import LocalRunner
 from tests.store.dynamo.utils import DYNAMODB_KWARGS
 
@@ -34,7 +34,8 @@ def test_extended_runner():
     assert len(local_runner._per_user_data) == 1
     assert len(local_runner._per_user_data['user-1'][0]) == 5
 
-    result_state = local_runner._per_user_data['user-1'][0][Key('user-1', 'state')]
+    result_state = local_runner._per_user_data['user-1'][0][Key(KeyType.DIMENSION, 'user-1',
+                                                                'state')]
     expected_state = {
         '_identity': 'user-1',
         'country': 'US',
@@ -58,7 +59,8 @@ def test_extended_runner():
 
     assert result_state == expected_state
 
-    result_session = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                  'session', [],
                                                                   datetime(2016, 2, 13, 0, 0, 58))]
     expected_session = {
         '_identity': 'user-1',
@@ -76,7 +78,8 @@ def test_extended_runner():
     }
     assert result_session == expected_session
 
-    result_session_10 = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session_10 = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                     'session', [],
                                                                      datetime(2016, 2, 10, 0, 0))]
     expected_session_10 = {
         '_identity': 'user-1',
@@ -94,7 +97,8 @@ def test_extended_runner():
 
     assert result_session_10 == expected_session_10
 
-    result_session_11 = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session_11 = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                     'session', [],
                                                                      datetime(2016, 2, 11, 0, 0))]
     expected_session_11 = {
         '_identity': 'user-1',
@@ -112,7 +116,8 @@ def test_extended_runner():
 
     assert result_session_11 == expected_session_11
 
-    result_session_12 = local_runner._per_user_data['user-1'][0][Key('user-1', 'session',
+    result_session_12 = local_runner._per_user_data['user-1'][0][Key(KeyType.TIMESTAMP, 'user-1',
+                                                                     'session', [],
                                                                      datetime(2016, 2, 12, 0, 0))]
     expected_session_12 = {
         '_identity': 'user-1',

--- a/tests/store/dynamo/dynamo_store_test.py
+++ b/tests/store/dynamo/dynamo_store_test.py
@@ -7,7 +7,7 @@ import boto3
 from pytest import fixture
 
 from blurr.core.schema_loader import SchemaLoader
-from blurr.core.store_key import Key
+from blurr.core.store_key import Key, KeyType
 from blurr.store.dynamo_store import DynamoStore
 from tests.store.dynamo.utils import DYNAMODB_KWARGS
 
@@ -54,55 +54,65 @@ def loaded_store() -> DynamoStore:
             new=override_boto3_dynamodb_resource):
         dynamo_store = schema_loader.get_store(name)
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 1, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string',
-            'int_field': 1
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 1, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string',
+                'int_field': 1
+            })
     dynamo_store.save(
-        Key('test_user2', 'test_group', datetime(2018, 1, 1, 1, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string',
-            'int_field': 1
-        })
+        Key(KeyType.TIMESTAMP, 'test_user2', 'test_group', [],
+            datetime(2018, 1, 1, 1, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string',
+                'int_field': 1
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 2, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string2',
-            'int_field': 2
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 2, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string2',
+                'int_field': 2
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 3, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string3',
-            'int_field': 3
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 3, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string3',
+                'int_field': 3
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 4, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string4',
-            'int_field': 4
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 4, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string4',
+                'int_field': 4
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 5, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string5',
-            'int_field': 5
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 5, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string5',
+                'int_field': 5
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string6',
-            'int_field': 6
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string6',
+                'int_field': 6
+            })
     dynamo_store.save(
-        Key('test_user2', 'test_group', datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string6',
-            'int_field': 6
-        })
+        Key(KeyType.TIMESTAMP, 'test_user2', 'test_group', [],
+            datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string6',
+                'int_field': 6
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 7, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string7',
-            'int_field': 7
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 7, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string7',
+                'int_field': 7
+            })
     dynamo_store.save(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 8, 1, 1, 1, tzinfo=timezone.utc)), {
-            'string_field': 'string8',
-            'int_field': 8
-        })
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 8, 1, 1, 1, tzinfo=timezone.utc)), {
+                'string_field': 'string8',
+                'int_field': 8
+            })
 
     yield dynamo_store
     dynamo_store._table.delete()
@@ -170,18 +180,25 @@ def test_table_creation_if_not_exist(dynamo_store_spec: Dict[str, Any]) -> None:
 
 
 def test_save_simple(store: DynamoStore) -> None:
-    store.save(Key('test_user', 'test_group'), {'string_field': 'string', 'int_field': 1})
-    assert store.get(Key('test_user', 'test_group')) == {'string_field': 'string', 'int_field': 1}
+    store.save(
+        Key(KeyType.DIMENSION, 'test_user', 'test_group'), {
+            'string_field': 'string',
+            'int_field': 1
+        })
+    assert store.get(Key(KeyType.DIMENSION, 'test_user', 'test_group')) == {
+        'string_field': 'string',
+        'int_field': 1
+    }
 
 
 def test_save_time(store: DynamoStore) -> None:
     start_time = datetime(2018, 1, 1, 1, 1, 1, 1, tzinfo=timezone.utc)
     store.save(
-        Key('test_user', 'test_group', start_time), {
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [], start_time), {
             'string_field': 'string2',
             'int_field': 2
         })
-    assert store.get(Key('test_user', 'test_group', start_time)) == {
+    assert store.get(Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [], start_time)) == {
         'string_field': 'string2',
         'int_field': 2
     }
@@ -189,8 +206,10 @@ def test_save_time(store: DynamoStore) -> None:
 
 def test_get_range_items_on_boundary_are_removed(loaded_store: DynamoStore) -> None:
     items = loaded_store.get_range(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 2, 1, 1, 1, tzinfo=timezone.utc)),
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)))
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 2, 1, 1, 1, tzinfo=timezone.utc)),
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)))
 
     assert len(items) == 3
     assert items[0][1]['int_field'] == 3
@@ -199,8 +218,10 @@ def test_get_range_items_on_boundary_are_removed(loaded_store: DynamoStore) -> N
 
 def test_get_range_no_items_on_boundary(loaded_store: DynamoStore) -> None:
     items = loaded_store.get_range(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 2, 1, 1, 0, tzinfo=timezone.utc)),
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 6, 1, 1, 2, tzinfo=timezone.utc)))
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 2, 1, 1, 0, tzinfo=timezone.utc)),
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 6, 1, 1, 2, tzinfo=timezone.utc)))
 
     assert len(items) == 5
     assert items[0][1]['int_field'] == 2
@@ -209,8 +230,8 @@ def test_get_range_no_items_on_boundary(loaded_store: DynamoStore) -> None:
 
 def test_get_range_count_forward(loaded_store: DynamoStore) -> None:
     items = loaded_store.get_range(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 2, 1, 1, 1, tzinfo=timezone.utc)), None,
-        3)
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 2, 1, 1, 1, tzinfo=timezone.utc)), None, 3)
 
     assert len(items) == 3
     assert items[0][1]['int_field'] == 3
@@ -219,8 +240,8 @@ def test_get_range_count_forward(loaded_store: DynamoStore) -> None:
 
 def test_get_range_count_backward(loaded_store: DynamoStore) -> None:
     items = loaded_store.get_range(
-        Key('test_user', 'test_group', datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)), None,
-        -3)
+        Key(KeyType.TIMESTAMP, 'test_user', 'test_group', [],
+            datetime(2018, 1, 1, 6, 1, 1, 1, tzinfo=timezone.utc)), None, -3)
 
     assert len(items) == 3
     assert items[0][1]['int_field'] == 5


### PR DESCRIPTION
#### Pull Request Checklist:
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

### What kind of change does this PR introduce?
Added a TIMESTAMP and DIMENSION KeyType to lay the ground work of making the Key class aware of the type of key that is being used.

For timestamp keys, time is a part of the sort key generated but for dimension keys time is not a part of the sort key. This is so that the item stored against the key can be retrieved with just the dimensions. Time based queries on dimension keys would have to be done on a secondary index or would require a partition + group scan.

Changing Block aggregate to dimensions instead of split condition will be in the next PR.
