### PR TITLE
Updated playground links and simplified readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,50 +4,32 @@
 [![Documentation Status](https://readthedocs.org/projects/productml-blurr/badge/?version=latest)](http://productml-blurr.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/productml/blurr/badge.svg?branch=master)](https://coveralls.io/github/productml/blurr?branch=master)
 [![PyPI version](https://badge.fury.io/py/blurr.svg)](https://badge.fury.io/py/blurr)
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/productml/blurr-examples/master)
 
 # Table of contents
 
 - [What is Blurr](#what-is-blurr)
 - [Is Blurr for you?](#is-blurr-for-you)
-- [Blurr is MLOps](#blurr-is-mlops)
+- [Playground](#playground)
 - [Tutorial & Docs](#tutorial-and-docs)
-- [Try Blurr](#try-blurr)
 - [Contribute](#contribute-to-blurr)
 - [Data Science 'Joel Test'](#data-science-joel-test)
 - [Roadmap](#roadmap)
 
 # What is Blurr?
 
-Blurr transforms structured, streaming `raw data` into `features` for model training and prediction using a `high-level expressive YAML-based language` called the Data Transform Configuration (DTC).
+Blurr transforms structured, streaming `raw data` into `features` for model training and prediction using a `high-level expressive YAML-based language` called the Data Transform Configuration (DTC). This merges the schema and the computation model for data transformations.
 
 The DTC is a __data transform definition__ for structured data. The DTC encapsulates the *business logic* of data transforms and Blurr orchestrates the *execution* of data transforms. Blurr is runner-agnostic, so DTCs can be run by event processors such as Spark, Spark Streaming or Flink.
 
-![Blurr Training](docs/images/blurr-in-training.png)
-
-This looks like any other ETL pipeline. At this point, Blurr doesn't do anything special that you cannot do with Spark, for instance. Blurr shines when an offline model pipeline needs to be turned into an online scoring pipeline.
-
-![Blurr Production](docs/images/blurr-in-prod.png)
-
 # Is Blurr for you?
 
-Blurr is for you if:
-
-1. You are well on your way on the ML 'curve of enlightenment', and are thinking about how to do online scoring
+Yes, if: you are well on your way on the ML 'curve of enlightenment', and are thinking about how to do online scoring
 
 ![Curve](docs/images/curve.png)
 
-2. You self-identify as a data scientist, a data engineer, or an ML engineer. But you believe that these distinctions are temporary. With the right tools, these are all one person. `data science`, `operations`, and `engineering` working together with minimal dependencies is critical to success of production ML efforts.    
+# Playground
 
-# Blurr is MLOps
-
-Blurr is a collection of components built for MLOps, the Blurr Core library is one of them. **Blurr Core ⊆ Blurr**
-
->We believe in a world where everyone is a data engineer. Or a data scientist. Or an ML engineer. The lines are blurred (*cough*). Just like development and operations became DevOps over time
-
-We see a future where MLOps means teams putting together various technologies to suit their needs. For production ML applications, the __speed of experimentation__ and __iterations__ is the difference between success and failure. The __DTC helps teams iterate on features faster__. The vision for Blurr is to build MLOps components to help ML teams experiment at high speed.
-
-[How to build AI culture: go through the curve of enlightenment](https://hackernoon.com/how-to-build-ai-culture-go-through-the-curve-of-enlightenment-21c239c1d5a7)
+An end-to-end NYSE price [prediction example using Blurr](https://colab.research.google.com/drive/1XU8G7as4cuPYqcoV5rJAd8yMuXUPXU8Q)
 
 # Tutorial and Docs
 
@@ -60,28 +42,9 @@ We see a future where MLOps means teams putting together various technologies to
 
 Preparing data for specific use cases using Blurr:
 
-* [Dynamic in-game offers (Offer AI)](docs/examples/offer-ai/offer-ai-walkthrough.md) 
+* [Dynamic in-game offers (Offer AI)](docs/examples/offer-ai/offer-ai-walkthrough.md)
 * [Frequently Bought Together](docs/examples/frequently-bought-together/fbt-walkthrough.md)
-* [New York Stock Exchange Prediction](https://mybinder.org/v2/gh/productml/blurr-examples/master?filepath=nyse%2Fnyse.ipynb)
 
-# Try Blurr
-
-One way to interact with Blurr is by using a Command Line Interface (CLI). The CLI is used to run blurr
-locally and is a great way of validating and testing the DTCs before deploying them in 
-production. 
-
-`$ pip install blurr`
-
-Transform data
-
-```
-$ blurr transform \
-     --streaming-dtc ./dtcs/sessionize-dtc.yml \
-     --window-dtc ./dtcs/windowing-dtc.yml \
-     --source file://path
-```
-
-[CLI documentation](http://productml-blurr.readthedocs.io/en/latest/Blurr%20CLI/)
 
 # Contribute to Blurr
 


### PR DESCRIPTION
#### Pull Request Checklist:
- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

### What kind of change does this PR introduce?
Updated playground link and simplified readme. The playground and tutorial are now on Google Colab. 

NYSE: https://colab.research.google.com/drive/1XU8G7as4cuPYqcoV5rJAd8yMuXUPXU8Q 
Tutorial: https://colab.research.google.com/drive/115yDN3PagEUpcLAh82F0XnbGVUVXRyJA#scrollTo=JJLcCRlz98cA 

#### Link to issue
fixes #282 

